### PR TITLE
Add initial babel-plugin code

### DIFF
--- a/babel-common/package.json
+++ b/babel-common/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@binaris/shift-babel-common",
+  "version": "0.0.0",
+  "description": "Common babel code for transforming ShiftJS exposed functions",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rm -rf dist/ && tsc",
+    "lint": "tslint -c ../common/tslint.yml -p .",
+    "test": "echo \"no tests to run\""
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/types": "^7.5.0",
+    "tslint": "^5.18.0",
+    "typescript": "^3.5.3"
+  }
+}

--- a/babel-common/package.json
+++ b/babel-common/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@binaris/shift-babel-common",
   "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
   "description": "Common babel code for transforming ShiftJS exposed functions",
   "main": "dist/index.js",
   "scripts": {

--- a/babel-common/src/index.ts
+++ b/babel-common/src/index.ts
@@ -1,0 +1,9 @@
+import * as BabelTypes from '@babel/types';
+
+export function getFunctionName(e: BabelTypes.FunctionDeclaration, t: typeof BabelTypes): string | undefined {
+  return t.isIdentifier(e.id) ? e.id.name : undefined;
+}
+
+export function isExposedStatement(node: BabelTypes.BaseNode) {
+  return node.leadingComments && node.leadingComments.some((comment) => /@expose/.test(comment.value));
+}

--- a/babel-common/src/index.ts
+++ b/babel-common/src/index.ts
@@ -7,3 +7,16 @@ export function getFunctionName(e: BabelTypes.FunctionDeclaration, t: typeof Bab
 export function isExposedStatement(node: BabelTypes.BaseNode) {
   return node.leadingComments && node.leadingComments.some((comment) => /@expose/.test(comment.value));
 }
+
+export function isTypeScriptGeneratedExport(e: BabelTypes.BaseNode, t: typeof BabelTypes, funcName: string) {
+  return t.isExpressionStatement(e) &&
+    t.isAssignmentExpression(e.expression) &&
+    e.expression.operator === '=' &&
+    t.isMemberExpression(e.expression.left) &&
+    t.isIdentifier(e.expression.left.object) &&
+    e.expression.left.object.name === 'exports' &&
+    t.isIdentifier(e.expression.left.property) &&
+    e.expression.left.property.name === funcName &&
+    t.isIdentifier(e.expression.right) &&
+    e.expression.right.name === funcName;
+}

--- a/babel-common/tsconfig.json
+++ b/babel-common/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../common/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}
+

--- a/babel-macro/package.json
+++ b/babel-macro/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/parser": "^7.5.0",
+    "@binaris/shift-babel-common": "0.0.0",
     "babel-plugin-macros": "^2.6.1"
   },
   "devDependencies": {

--- a/babel-macro/src/macro.ts
+++ b/babel-macro/src/macro.ts
@@ -3,7 +3,7 @@ import { parse } from '@babel/parser';
 // not using since not sure if babel.types is the very same babel.types or a different version
 // import * as t from '@babel/types';
 import * as babelTypes from '@babel/types';
-import { getFunctionName, isExposedStatement } from '@binaris/shift-babel-common';
+import { getFunctionName, isExposedStatement, isTypeScriptGeneratedExport } from '@binaris/shift-babel-common';
 import { readFileSync } from 'fs';
 import path from 'path';
 
@@ -30,18 +30,7 @@ function assertExportedMember(ast: babelTypes.File, t: typeof babelTypes, funcNa
   // exports.funcName = funcName
   // we support this because this is the TypeScript's generated pattern for named exports
   const { body } = ast.program;
-  const isFunctionExported = body.some((e) =>
-    t.isExpressionStatement(e) &&
-    t.isAssignmentExpression(e.expression) &&
-    e.expression.operator === '=' &&
-    t.isMemberExpression(e.expression.left) &&
-    t.isIdentifier(e.expression.left.object) &&
-    e.expression.left.object.name === 'exports' &&
-    t.isIdentifier(e.expression.left.property) &&
-    e.expression.left.property.name === funcName &&
-    t.isIdentifier(e.expression.right) &&
-    e.expression.right.name === funcName
-  );
+  const isFunctionExported = body.some((e) => isTypeScriptGeneratedExport(e, t, funcName));
   if (!isFunctionExported) {
     throw new Error(`${funcName} has @expose decorator but it is not exported`);
   }

--- a/babel-plugin/README.md
+++ b/babel-plugin/README.md
@@ -1,0 +1,1 @@
+This is a plugin that detects @exposed functions and marks them as exposed.

--- a/babel-plugin/ignored.d.ts
+++ b/babel-plugin/ignored.d.ts
@@ -1,0 +1,1 @@
+declare module 'babel-plugin-tester';

--- a/babel-plugin/jest.config.js
+++ b/babel-plugin/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  "roots": [
+    "<rootDir>/dist/test"
+  ],
+  "reporters": ["jest-standard-reporter"],
+  "modulePaths": [
+    "<rootDir>/dist/"
+  ],
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.js$",
+  "moduleFileExtensions": [
+    "js"
+  ],
+  "testEnvironment": "node",
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "dist/!(test)**/**/*.js"
+  ]
+}

--- a/babel-plugin/package.json
+++ b/babel-plugin/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@binaris/shift-backend-babel-plugin",
   "version": "0.0.0",
+  "files": [
+    "dist"
+  ],
   "description": "Babel plugin for marking exposed functions",
   "main": "dist/index.js",
   "scripts": {

--- a/babel-plugin/package.json
+++ b/babel-plugin/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@binaris/shift-babel-plugin",
+  "version": "0.0.0",
+  "description": "Babel plugin for marking exposed functions",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rm -rf dist/ && tsc",
+    "lint": "tslint -c ../common/tslint.yml -p .",
+    "test": "jest"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@binaris/shift-babel-common": "0.0.0"
+  },
+  "devDependencies": {
+    "@babel/types": "^7.5.0",
+    "@types/babel__traverse": "^7.0.7",
+    "babel-plugin-tester": "^6.4.0",
+    "jest": "^24.8.0",
+    "jest-standard-reporter": "^1.0.1",
+    "typescript": "^3.5.3"
+  }
+}

--- a/babel-plugin/package.json
+++ b/babel-plugin/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@binaris/shift-babel-plugin",
+  "name": "@binaris/shift-backend-babel-plugin",
   "version": "0.0.0",
   "description": "Babel plugin for marking exposed functions",
   "main": "dist/index.js",

--- a/babel-plugin/src/index.ts
+++ b/babel-plugin/src/index.ts
@@ -12,7 +12,9 @@ function insertExpose(path: NodePath<BabelTypes.Node>, t: typeof BabelTypes, fun
     t.expressionStatement(
       t.assignmentExpression('=',
         t.memberExpression(t.identifier(funcName), t.identifier('__shiftjs__')),
-        t.stringLiteral('exposed')
+        t.objectExpression([
+          t.objectProperty(t.identifier('exposed'), t.booleanLiteral(true)),
+        ]),
       )
     )
   );

--- a/babel-plugin/src/index.ts
+++ b/babel-plugin/src/index.ts
@@ -1,0 +1,37 @@
+import * as BabelTypes from '@babel/types';
+// tslint:disable-next-line:no-implicit-dependencies only used for Visitor type
+import { Visitor } from '@babel/traverse';
+import { getFunctionName, isExposedStatement } from '@binaris/shift-babel-common';
+
+interface Babel {
+  types: typeof BabelTypes;
+}
+
+export default function({ types: t }: Babel): { visitor: Visitor<object> } {
+  return {
+    visitor: {
+      ExportNamedDeclaration(path) {
+        const { node } = path;
+        if (!isExposedStatement(node)) {
+          return;
+        }
+        const { declaration } = node;
+        if (!t.isFunctionDeclaration(declaration)) {
+          return;
+        }
+        const funcName = getFunctionName(declaration, t);
+        if (!funcName) {
+          return;
+        }
+        path.insertAfter(
+          t.expressionStatement(
+            t.assignmentExpression('=',
+              t.memberExpression(t.identifier(funcName), t.identifier('__shiftjs__')),
+              t.stringLiteral('exposed')
+            )
+          )
+        );
+      },
+    },
+  };
+}

--- a/babel-plugin/src/test/plugin.spec.ts
+++ b/babel-plugin/src/test/plugin.spec.ts
@@ -1,0 +1,24 @@
+import pluginTester from 'babel-plugin-tester';
+import plugin from '../';
+
+pluginTester({
+  plugin,
+  pluginName: '@binaris/shift-babel-plugin',
+  tests: {
+    'Mark @exposed functions as exposed': {
+      code: `
+        // @expose
+        export async function hello() {
+          return 42;
+        }
+      `,
+      output: `
+        // @expose
+        export async function hello() {
+          return 42;
+        }
+        hello.__shiftjs__ = "exposed";
+      `,
+    },
+  },
+});

--- a/babel-plugin/src/test/plugin.spec.ts
+++ b/babel-plugin/src/test/plugin.spec.ts
@@ -3,7 +3,7 @@ import plugin from '../';
 
 pluginTester({
   plugin,
-  pluginName: '@binaris/shift-babel-plugin',
+  pluginName: '@binaris/shift-backend-babel-plugin',
   tests: {
     'Mark @exposed functions as exposed': {
       code: `

--- a/babel-plugin/src/test/plugin.spec.ts
+++ b/babel-plugin/src/test/plugin.spec.ts
@@ -17,7 +17,9 @@ pluginTester({
         export async function hello() {
           return 42;
         }
-        hello.__shiftjs__ = "exposed";
+        hello.__shiftjs__ = {
+          exposed: true
+        };
       `,
     },
     'Mark @exposed TypeScript output functions as exposed': {
@@ -34,7 +36,9 @@ pluginTester({
           return 42;
         }
 
-        hello.__shiftjs__ = "exposed";
+        hello.__shiftjs__ = {
+          exposed: true
+        };
         exports.hello = hello;
       `,
     },

--- a/babel-plugin/src/test/plugin.spec.ts
+++ b/babel-plugin/src/test/plugin.spec.ts
@@ -20,5 +20,23 @@ pluginTester({
         hello.__shiftjs__ = "exposed";
       `,
     },
+    'Mark @exposed TypeScript output functions as exposed': {
+      code: `
+        // @expose
+        function hello() {
+          return 42;
+        }
+        exports.hello = hello;
+      `,
+      output: `
+        // @expose
+        function hello() {
+          return 42;
+        }
+
+        hello.__shiftjs__ = "exposed";
+        exports.hello = hello;
+      `,
+    },
   },
 });

--- a/babel-plugin/tsconfig.json
+++ b/babel-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../common/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}
+

--- a/common/changes/@binaris/shift-babel-common/babel-plugin_2019-07-16-11-34.json
+++ b/common/changes/@binaris/shift-babel-common/babel-plugin_2019-07-16-11-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-babel-common",
+      "comment": "Use common module for some babel code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-babel-common",
+  "email": "vladimir@binaris.com"
+}

--- a/common/changes/@binaris/shift-babel-macro/babel-plugin_2019-07-16-11-34.json
+++ b/common/changes/@binaris/shift-babel-macro/babel-plugin_2019-07-16-11-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-babel-macro",
+      "comment": "Use common module for some babel code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-babel-macro",
+  "email": "vladimir@binaris.com"
+}

--- a/common/changes/@binaris/shift-babel-plugin/babel-plugin_2019-07-16-11-34.json
+++ b/common/changes/@binaris/shift-babel-plugin/babel-plugin_2019-07-16-11-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-babel-plugin",
+      "comment": "Add initial babel backend plugin",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-babel-plugin",
+  "email": "vladimir@binaris.com"
+}

--- a/common/changes/@binaris/shift-backend-babel-plugin/babel-plugin_2019-07-16-11-34.json
+++ b/common/changes/@binaris/shift-backend-babel-plugin/babel-plugin_2019-07-16-11-34.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "packageName": "@binaris/shift-babel-plugin",
+      "packageName": "@binaris/shift-backend-babel-plugin",
       "comment": "Add initial babel backend plugin",
       "type": "patch"
     }
   ],
-  "packageName": "@binaris/shift-babel-plugin",
+  "packageName": "@binaris/shift-backend-babel-plugin",
   "email": "vladimir@binaris.com"
 }

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,21 +1,24 @@
 dependencies:
-  '@babel/cli': 7.5.0
-  '@babel/core': 7.5.4
-  '@babel/parser': 7.5.0
+  '@babel/cli': 7.5.5
+  '@babel/core': 7.5.5
+  '@babel/parser': 7.5.5
   '@babel/plugin-transform-modules-commonjs': 7.5.0
-  '@babel/types': 7.5.0
+  '@babel/types': 7.5.5
   '@octokit/rest': 16.28.4
   '@rush-temp/rush-update': 'file:projects/rush-update.tgz'
+  '@rush-temp/shift-babel-common': 'file:projects/shift-babel-common.tgz'
   '@rush-temp/shift-babel-macro': 'file:projects/shift-babel-macro.tgz'
+  '@rush-temp/shift-backend-babel-plugin': 'file:projects/shift-backend-babel-plugin.tgz'
   '@rush-temp/shift-db': 'file:projects/shift-db.tgz'
   '@rush-temp/shift-fetch-runtime': 'file:projects/shift-fetch-runtime.tgz'
   '@rush-temp/shift-interfaces': 'file:projects/shift-interfaces.tgz'
   '@rush-temp/shift-local-proxy': 'file:projects/shift-local-proxy.tgz'
   '@types/babel__core': 7.1.2
+  '@types/babel__traverse': 7.0.7
   '@types/bunyan': 1.8.6
   '@types/deep-freeze': 0.1.1
   '@types/express': 4.17.0
-  '@types/got': 9.6.1
+  '@types/got': 9.6.2
   '@types/http-proxy': 1.17.0
   '@types/jest': 24.0.15
   '@types/jju': 1.4.1
@@ -25,7 +28,7 @@ dependencies:
   '@types/lodash.once': 4.1.6
   '@types/mkdirp': 0.5.2
   '@types/nanoid': 2.0.0
-  '@types/ramda': 0.26.15
+  '@types/ramda': 0.26.16
   '@types/rimraf': 2.0.2
   '@types/rmfr': 2.0.0
   '@types/yargs': 13.0.0
@@ -66,12 +69,12 @@ packages:
       node: '>=6.12.3 <7 || >=8.9.4 <9 || >=10.0.0'
     resolution:
       integrity: sha512-mN9UolOs4WX09QkheU1ELkVy2WPnwonlO3XMdN8JF8fQqRVgVTR21xDbvEOUsbwz6Zwjq7ji9yzyjuXqDPalxg==
-  /@ava/babel-preset-stage-4/3.0.0/@babel!core@7.5.4:
+  /@ava/babel-preset-stage-4/3.0.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.5.4
-      '@babel/plugin-proposal-optional-catch-binding': /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.5.4
-      '@babel/plugin-transform-dotall-regex': /@babel/plugin-transform-dotall-regex/7.4.4/@babel!core@7.5.4
-      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.4
+      '@babel/plugin-proposal-async-generator-functions': /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.5.5
+      '@babel/plugin-proposal-optional-catch-binding': /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.5.5
+      '@babel/plugin-transform-dotall-regex': /@babel/plugin-transform-dotall-regex/7.4.4/@babel!core@7.5.5
+      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.5
     dev: false
     engines:
       node: '>=8.9.4 <9 || >=10.0.0'
@@ -87,7 +90,7 @@ packages:
       node: '>=6.12.3 <7 || >=8.9.4 <9 || >=10.0.0'
     resolution:
       integrity: sha512-rqgyQwkT0+j2JzYP51dOv80u33rzAvjBtXRzUON+7+6u26mjoudRXci2+1s18rat8r4uOlZfbzm114YS6pwmYw==
-  /@babel/cli/7.5.0:
+  /@babel/cli/7.5.5:
     dependencies:
       commander: 2.20.0
       convert-source-map: 1.6.0
@@ -105,10 +108,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-qNH55fWbKrEsCwID+Qc/3JDPnsSGpIIiMDbppnR8Z6PxLAqMQCFNqBctkIkBrMH49Nx+qqVTrHRWUR+ho2k+qQ==
-  /@babel/cli/7.5.0/@babel!core@7.5.4:
+      integrity: sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==
+  /@babel/cli/7.5.5/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       commander: 2.20.0
       convert-source-map: 1.6.0
       fs-readdir-recursive: 1.1.0
@@ -120,28 +123,28 @@ packages:
       source-map: 0.5.7
     dev: false
     hasBin: true
-    id: registry.npmjs.org/@babel/cli/7.5.0
+    id: registry.npmjs.org/@babel/cli/7.5.5
     optionalDependencies:
       chokidar: 2.1.6
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-qNH55fWbKrEsCwID+Qc/3JDPnsSGpIIiMDbppnR8Z6PxLAqMQCFNqBctkIkBrMH49Nx+qqVTrHRWUR+ho2k+qQ==
-  /@babel/code-frame/7.0.0:
+      integrity: sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==
+  /@babel/code-frame/7.5.5:
     dependencies:
       '@babel/highlight': 7.5.0
     dev: false
     resolution:
-      integrity: sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
-  /@babel/core/7.5.4:
+      integrity: sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  /@babel/core/7.5.5:
     dependencies:
-      '@babel/code-frame': 7.0.0
-      '@babel/generator': 7.5.0
-      '@babel/helpers': 7.5.4
-      '@babel/parser': 7.5.0
+      '@babel/code-frame': 7.5.5
+      '@babel/generator': 7.5.5
+      '@babel/helpers': 7.5.5
+      '@babel/parser': 7.5.5
       '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/traverse': 7.5.5
+      '@babel/types': 7.5.5
       convert-source-map: 1.6.0
       debug: 4.1.1
       json5: 2.1.0
@@ -153,20 +156,20 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==
-  /@babel/generator/7.5.0:
+      integrity: sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==
+  /@babel/generator/7.5.5:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
       jsesc: 2.5.2
       lodash: 4.17.14
       source-map: 0.5.7
       trim-right: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==
+      integrity: sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
   /@babel/helper-annotate-as-pure/7.0.0:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
@@ -174,63 +177,63 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.0.0
       '@babel/template': 7.4.4
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
   /@babel/helper-get-function-arity/7.0.0:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   /@babel/helper-module-imports/7.0.0:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==
-  /@babel/helper-module-transforms/7.4.4:
+  /@babel/helper-module-transforms/7.5.5:
     dependencies:
       '@babel/helper-module-imports': 7.0.0
       '@babel/helper-simple-access': 7.1.0
       '@babel/helper-split-export-declaration': 7.4.4
       '@babel/template': 7.4.4
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
       lodash: 4.17.14
     dev: false
     resolution:
-      integrity: sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==
+      integrity: sha512-jBeCvETKuJqeiaCdyaheF40aXnnU1+wkSiUs/IQg3tB85up1LyL8x77ClY8qJpuRJUcXQo+ZtdNESmZl4j56Pw==
   /@babel/helper-plugin-utils/7.0.0:
     dev: false
     resolution:
       integrity: sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
-  /@babel/helper-regex/7.4.4:
+  /@babel/helper-regex/7.5.5:
     dependencies:
       lodash: 4.17.14
     dev: false
     resolution:
-      integrity: sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==
+      integrity: sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==
   /@babel/helper-remap-async-to-generator/7.1.0:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.0.0
       '@babel/helper-wrap-function': 7.2.0
       '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/traverse': 7.5.5
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==
   /@babel/helper-simple-access/7.1.0:
     dependencies:
       '@babel/template': 7.4.4
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==
   /@babel/helper-split-export-declaration/7.4.4:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
@@ -238,19 +241,19 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.1.0
       '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/traverse': 7.5.5
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==
-  /@babel/helpers/7.5.4:
+  /@babel/helpers/7.5.5:
     dependencies:
       '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/traverse': 7.5.5
+      '@babel/types': 7.5.5
     dev: false
     resolution:
-      integrity: sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==
+      integrity: sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==
   /@babel/highlight/7.5.0:
     dependencies:
       chalk: 2.4.2
@@ -259,39 +262,39 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
-  /@babel/parser/7.5.0:
+  /@babel/parser/7.5.5:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==
-  /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.5.4:
+      integrity: sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
+  /@babel/plugin-proposal-async-generator-functions/7.2.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-remap-async-to-generator': 7.1.0
-      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.4
+      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.5
     dev: false
     id: registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==
-  /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.5.4:
+  /@babel/plugin-proposal-optional-catch-binding/7.2.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.4
+      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.5
     dev: false
     id: registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/7.2.0
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==
-  /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.4:
+  /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
     id: registry.npmjs.org/@babel/plugin-syntax-async-generators/7.2.0
@@ -299,9 +302,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
-  /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.4:
+  /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
     id: registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/7.2.0
@@ -309,9 +312,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==
-  /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.4:
+  /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
     dev: false
     id: registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/7.2.0
@@ -319,11 +322,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
-  /@babel/plugin-transform-dotall-regex/7.4.4/@babel!core@7.5.4:
+  /@babel/plugin-transform-dotall-regex/7.4.4/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
-      '@babel/helper-regex': 7.4.4
+      '@babel/helper-regex': 7.5.5
       regexpu-core: 4.5.4
     dev: false
     engines:
@@ -335,7 +338,7 @@ packages:
       integrity: sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
   /@babel/plugin-transform-modules-commonjs/7.5.0:
     dependencies:
-      '@babel/helper-module-transforms': 7.4.4
+      '@babel/helper-module-transforms': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.1.0
       babel-plugin-dynamic-import-node: 2.3.0
@@ -344,10 +347,10 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==
-  /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.4:
+  /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
-      '@babel/helper-module-transforms': 7.4.4
+      '@babel/core': 7.5.5
+      '@babel/helper-module-transforms': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.1.0
       babel-plugin-dynamic-import-node: 2.3.0
@@ -357,42 +360,42 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==
-  /@babel/runtime/7.5.4:
+  /@babel/runtime/7.5.5:
     dependencies:
       regenerator-runtime: 0.13.2
     dev: false
     resolution:
-      integrity: sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==
+      integrity: sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
   /@babel/template/7.4.4:
     dependencies:
-      '@babel/code-frame': 7.0.0
-      '@babel/parser': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/code-frame': 7.5.5
+      '@babel/parser': 7.5.5
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
-  /@babel/traverse/7.5.0:
+  /@babel/traverse/7.5.5:
     dependencies:
-      '@babel/code-frame': 7.0.0
-      '@babel/generator': 7.5.0
+      '@babel/code-frame': 7.5.5
+      '@babel/generator': 7.5.5
       '@babel/helper-function-name': 7.1.0
       '@babel/helper-split-export-declaration': 7.4.4
-      '@babel/parser': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/parser': 7.5.5
+      '@babel/types': 7.5.5
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.14
     dev: false
     resolution:
-      integrity: sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==
-  /@babel/types/7.5.0:
+      integrity: sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+  /@babel/types/7.5.5:
     dependencies:
       esutils: 2.0.2
       lodash: 4.17.14
       to-fast-properties: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==
+      integrity: sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
   /@cnakazawa/watch/1.0.3:
     dependencies:
       exec-sh: 0.3.2
@@ -537,7 +540,7 @@ packages:
       integrity: sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==
   /@jest/transform/24.8.0:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@jest/types': 24.8.0
       babel-plugin-istanbul: 5.1.4
       chalk: 2.4.2
@@ -582,7 +585,7 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
-  /@octokit/endpoint/5.2.2:
+  /@octokit/endpoint/5.3.0:
     dependencies:
       deepmerge: 4.0.0
       is-plain-object: 3.0.0
@@ -590,7 +593,7 @@ packages:
       url-template: 2.0.8
     dev: false
     resolution:
-      integrity: sha512-VhKxM4CQanIUZDffExqpdpgqu3heF51qbY1wazoNtvIKXAAVoFjqLq2BOhesXkTqxXMO1Ze1XbS8DkIjUxAB+g==
+      integrity: sha512-D7u80EdZHlHzYl81PgoKXFFIl121eLahKI6WFvuhwE4ih+U+YWrE1fGiH9eybr8l3mGgZ9iITYGBR+7UR5S9QA==
   /@octokit/request-error/1.0.4:
     dependencies:
       deprecation: 2.3.1
@@ -600,7 +603,7 @@ packages:
       integrity: sha512-L4JaJDXn8SGT+5G0uX79rZLv0MNJmfGa4vb4vy1NnpjSnWDLJRy6m90udGwvMmavwsStgbv2QNkPzzTCMmL+ig==
   /@octokit/request/5.0.1:
     dependencies:
-      '@octokit/endpoint': 5.2.2
+      '@octokit/endpoint': 5.3.0
       '@octokit/request-error': 1.0.4
       deprecation: 2.3.1
       is-plain-object: 3.0.0
@@ -648,8 +651,8 @@ packages:
       integrity: sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==
   /@types/babel__core/7.1.2:
     dependencies:
-      '@babel/parser': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/parser': 7.5.5
+      '@babel/types': 7.5.5
       '@types/babel__generator': 7.0.2
       '@types/babel__template': 7.0.2
       '@types/babel__traverse': 7.0.7
@@ -658,39 +661,39 @@ packages:
       integrity: sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==
   /@types/babel__generator/7.0.2:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/parser': 7.5.5
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
   /@types/babel__traverse/7.0.7:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
     dev: false
     resolution:
       integrity: sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   /@types/body-parser/1.17.0:
     dependencies:
       '@types/connect': 3.4.32
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
   /@types/bunyan/1.8.6:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==
   /@types/connect/3.4.32:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
@@ -704,7 +707,7 @@ packages:
       integrity: sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
   /@types/express-serve-static-core/4.16.7:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
       '@types/range-parser': 1.2.3
     dev: false
     resolution:
@@ -721,21 +724,21 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
-  /@types/got/9.6.1:
+  /@types/got/9.6.2:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
       '@types/tough-cookie': 2.3.5
       form-data: 2.5.0
     dev: false
     resolution:
-      integrity: sha512-910qhgjC0nhbrNU55ItiTJYoIBin0Ej0h11bH50GmetA5FKZ3UeH/Kit7vDx2myA8WiJR06FvC4H7kchA912/A==
+      integrity: sha512-Md/d9kSfdyZvVqhmUb3l+YPCmvIZG7qmM9hvW7dKJfTwpaZ4HBSqYpPhz3Dh0ywTfaEHKlFvPL+HMXIcNzP2tw==
   /@types/http-proxy/1.17.0:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-l+s0IoxSHqhLFJPDHRfO235kgrCkvFD8JmdV/T9C4BKBYPIjrQopGFH4r7h2e3jQqgJRCthRCAZIxDoFnj1zwQ==
@@ -773,14 +776,14 @@ packages:
   /@types/leveldown/4.0.0:
     dependencies:
       '@types/abstract-leveldown': 5.0.1
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-1+h/AaqhhQK1/Q1Nr1sHyy7JDcVmKosL9uYLb4bhdLf7MQP4f4daWRLuFQKp8n/pRbai2XPUpR7z33N85m2Hng==
   /@types/levelup/3.1.1:
     dependencies:
       '@types/abstract-leveldown': 5.0.1
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-LjvlfctJYj23Xuqq3jCT8ZPSUSSgDcRJg8+XFDBasoYzefFbB4cHzlDmBVjc2rBOYvklpYHJRayD0jBsbJLD9w==
@@ -804,28 +807,28 @@ packages:
       integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
   /@types/mkdirp/0.5.2:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
   /@types/nanoid/2.0.0:
     dependencies:
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-NtwPHfAyU3IDXdKAB2OMPpAauHBg9gUjpOYr3FAzI84D70nWdS8k5mryteLvT/s1ACeAFAkGg132/XJVN4qx/w==
-  /@types/node/10.14.12:
+  /@types/node/10.14.13:
     dev: false
     resolution:
-      integrity: sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==
-  /@types/node/12.6.3:
+      integrity: sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==
+  /@types/node/12.6.8:
     dev: false
     resolution:
-      integrity: sha512-7TEYTQT1/6PP53NftXXabIZDaZfaoBdeBm8Md/i7zsWRoBe0YwOXguyK8vhHs8ehgB/w9U4K/6EWuTyp0W6nIA==
-  /@types/ramda/0.26.15:
+      integrity: sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
+  /@types/ramda/0.26.16:
     dev: false
     resolution:
-      integrity: sha512-kmIO8GVOLv0A8UxFr5lJaqp4g8jbXNhH0grBaPL6NgkOqSirRKpV9+5DTmIDXTyq2G18YMdxDhnScEZtY4brtQ==
+      integrity: sha512-J+cv6Tm8tCovBt2SqEpy6Mzuf3XPPUW5X491yCHSgKs7epz2yNPupCik4BOIzpg5VF23cs6P2X8e66IUBPrgmQ==
   /@types/range-parser/1.2.3:
     dev: false
     resolution:
@@ -833,7 +836,7 @@ packages:
   /@types/rimraf/2.0.2:
     dependencies:
       '@types/glob': 7.1.1
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
     dev: false
     resolution:
       integrity: sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==
@@ -1204,13 +1207,13 @@ packages:
       integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
   /ava/2.1.0:
     dependencies:
-      '@ava/babel-preset-stage-4': /@ava/babel-preset-stage-4/3.0.0/@babel!core@7.5.4
+      '@ava/babel-preset-stage-4': /@ava/babel-preset-stage-4/3.0.0/@babel!core@7.5.5
       '@ava/babel-preset-transform-test-files': 5.0.0
-      '@babel/core': 7.5.4
-      '@babel/generator': 7.5.0
-      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.4
-      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.4
-      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.4
+      '@babel/core': 7.5.5
+      '@babel/generator': 7.5.5
+      '@babel/plugin-syntax-async-generators': /@babel/plugin-syntax-async-generators/7.2.0/@babel!core@7.5.5
+      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.5
+      '@babel/plugin-syntax-optional-catch-binding': /@babel/plugin-syntax-optional-catch-binding/7.2.0/@babel!core@7.5.5
       '@concordance/react': 2.0.0
       ansi-escapes: 4.2.0
       ansi-styles: 4.0.0
@@ -1294,14 +1297,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
-  /babel-jest/24.8.0/@babel!core@7.5.4:
+  /babel-jest/24.8.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@jest/transform': 24.8.0
       '@jest/types': 24.8.0
       '@types/babel__core': 7.1.2
       babel-plugin-istanbul: 5.1.4
-      babel-preset-jest: /babel-preset-jest/24.6.0/@babel!core@7.5.4
+      babel-preset-jest: /babel-preset-jest/24.6.0/@babel!core@7.5.5
       chalk: 2.4.2
       slash: 2.0.0
     dev: false
@@ -1320,8 +1323,8 @@ packages:
       integrity: sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   /babel-plugin-espower/3.0.1:
     dependencies:
-      '@babel/generator': 7.5.0
-      '@babel/parser': 7.5.0
+      '@babel/generator': 7.5.5
+      '@babel/parser': 7.5.5
       call-matcher: 1.1.0
       core-js: 2.6.9
       espower-location-detector: 1.0.0
@@ -1350,7 +1353,7 @@ packages:
       integrity: sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==
   /babel-plugin-macros/2.6.1:
     dependencies:
-      '@babel/runtime': 7.5.4
+      '@babel/runtime': 7.5.5
       cosmiconfig: 5.2.1
       resolve: 1.11.1
     dev: false
@@ -1371,10 +1374,10 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-Eyr6YmDuKRStZX6Jamv+C0IW40RxiJLJb6ogaf0jNcIwZ+/r9Nq2vaDUTZgWLps+bQBMTmn6rtHD3zJQecF3nA==
-  /babel-preset-jest/24.6.0/@babel!core@7.5.4:
+  /babel-preset-jest/24.6.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.4
-      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.4
+      '@babel/core': 7.5.5
+      '@babel/plugin-syntax-object-rest-spread': /@babel/plugin-syntax-object-rest-spread/7.2.0/@babel!core@7.5.5
       babel-plugin-jest-hoist: 24.6.0
     dev: false
     engines:
@@ -1573,7 +1576,7 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
-  /cacache/11.3.3:
+  /cacache/12.0.0:
     dependencies:
       bluebird: 3.5.5
       chownr: 1.1.2
@@ -1591,7 +1594,7 @@ packages:
       y18n: 4.0.0
     dev: false
     resolution:
-      integrity: sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
+      integrity: sha512-0baf1FhCp16LhN+xDJsOrSiaPDCTD3JegZptVmLDoEbFcT5aT+BeFGt3wcDU3olCP5tpTCXU5sv0+TsKWT9WGQ==
   /cache-base/1.0.1:
     dependencies:
       collection-visit: 1.0.0
@@ -3889,11 +3892,11 @@ packages:
       integrity: sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.5.0
-      '@babel/parser': 7.5.0
+      '@babel/generator': 7.5.5
+      '@babel/parser': 7.5.5
       '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/traverse': 7.5.5
+      '@babel/types': 7.5.5
       istanbul-lib-coverage: 2.0.5
       semver: 6.2.0
     dev: false
@@ -3964,10 +3967,10 @@ packages:
       integrity: sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==
   /jest-config/24.8.0:
     dependencies:
-      '@babel/core': 7.5.4
+      '@babel/core': 7.5.5
       '@jest/test-sequencer': 24.8.0
       '@jest/types': 24.8.0
-      babel-jest: /babel-jest/24.8.0/@babel!core@7.5.4
+      babel-jest: /babel-jest/24.8.0/@babel!core@7.5.5
       chalk: 2.4.2
       glob: 7.1.4
       jest-environment-jsdom: 24.8.0
@@ -4070,7 +4073,7 @@ packages:
       integrity: sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==
   /jest-jasmine2/24.8.0:
     dependencies:
-      '@babel/traverse': 7.5.0
+      '@babel/traverse': 7.5.5
       '@jest/environment': 24.8.0
       '@jest/test-result': 24.8.0
       '@jest/types': 24.8.0
@@ -4112,7 +4115,7 @@ packages:
       integrity: sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
   /jest-message-util/24.8.0:
     dependencies:
-      '@babel/code-frame': 7.0.0
+      '@babel/code-frame': 7.5.5
       '@jest/test-result': 24.8.0
       '@jest/types': 24.8.0
       '@types/stack-utils': 1.0.1
@@ -4238,7 +4241,7 @@ packages:
       integrity: sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==
   /jest-snapshot/24.8.0:
     dependencies:
-      '@babel/types': 7.5.0
+      '@babel/types': 7.5.5
       '@jest/types': 24.8.0
       chalk: 2.4.2
       expect: 24.8.0
@@ -4781,10 +4784,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
-  /make-fetch-happen/4.0.2:
+  /make-fetch-happen/5.0.0:
     dependencies:
       agentkeepalive: 3.5.2
-      cacache: 11.3.3
+      cacache: 12.0.0
       http-cache-semantics: 3.8.1
       http-proxy-agent: 2.1.0
       https-proxy-agent: 2.2.2
@@ -4796,7 +4799,7 @@ packages:
       ssri: 6.0.1
     dev: false
     resolution:
-      integrity: sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==
+      integrity: sha512-nFr/vpL1Jc60etMVKeaLOqfGjMMb3tAHFVJWxHOFCFS04Zmd7kGlMxo0l1tzfhoQje0/UPnd0X8OeGUiXXnfPA==
   /makeerror/1.0.11:
     dependencies:
       tmpl: 1.0.4
@@ -5261,7 +5264,7 @@ packages:
       libnpmconfig: 1.2.1
       lodash: 4.17.14
       node-alias: 1.0.4
-      pacote: 9.5.2
+      pacote: 9.5.4
       progress: 2.0.3
       prompts: 2.1.0
       rc-config-loader: 2.0.4
@@ -5300,17 +5303,17 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==
-  /npm-registry-fetch/3.9.1:
+  /npm-registry-fetch/4.0.0:
     dependencies:
       JSONStream: 1.3.5
       bluebird: 3.5.5
       figgy-pudding: 3.5.1
       lru-cache: 5.1.1
-      make-fetch-happen: 4.0.2
+      make-fetch-happen: 5.0.0
       npm-package-arg: 6.1.0
     dev: false
     resolution:
-      integrity: sha512-VQCEZlydXw4AwLROAXWUR7QDfe2Y8Id/vpAgp6TI1/H78a4SiQ1kQrKZALm5/zxM5n4HIi+aYb+idUAV/RuY0Q==
+      integrity: sha512-Jllq35Jag8dtv0M17ue74XtdQTyqKzuAYGiX9mAjOhkmNjib3bBUgK6mUY61+AHnXeSRobQkpY3/xIOS/omptw==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -5642,15 +5645,15 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==
-  /pacote/9.5.2:
+  /pacote/9.5.4:
     dependencies:
       bluebird: 3.5.5
-      cacache: 11.3.3
+      cacache: 12.0.0
       figgy-pudding: 3.5.1
       get-stream: 4.1.0
       glob: 7.1.4
       lru-cache: 5.1.1
-      make-fetch-happen: 4.0.2
+      make-fetch-happen: 5.0.0
       minimatch: 3.0.4
       minipass: 2.3.5
       mississippi: 3.0.0
@@ -5659,7 +5662,7 @@ packages:
       npm-package-arg: 6.1.0
       npm-packlist: 1.4.4
       npm-pick-manifest: 2.2.3
-      npm-registry-fetch: 3.9.1
+      npm-registry-fetch: 4.0.0
       osenv: 0.1.5
       promise-inflight: 1.0.1
       promise-retry: 1.1.1
@@ -5673,7 +5676,7 @@ packages:
       which: 1.3.1
     dev: false
     resolution:
-      integrity: sha512-KVxalD57jaHnWIBQKPeU/eFU4UoMqUOj3h5AXvVMp9oJd8BZvIdTm8qmazy4jpYBf7RX9xCFmeFcU3ebvrUSZQ==
+      integrity: sha512-nWr0ari6E+apbdoN0hToTKZElO5h4y8DGFa2pyNA5GQIdcP0imC96bA0bbPw1gpeguVIiUgHHaAlq/6xfPp8Qw==
   /parallel-transform/1.1.0:
     dependencies:
       cyclist: 0.2.2
@@ -7139,7 +7142,7 @@ packages:
       integrity: sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
   /tslint/5.18.0:
     dependencies:
-      '@babel/code-frame': 7.0.0
+      '@babel/code-frame': 7.5.5
       builtin-modules: 1.1.1
       chalk: 2.4.2
       commander: 2.20.0
@@ -7162,7 +7165,7 @@ packages:
       integrity: sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==
   /tslint/5.18.0/typescript@3.5.3:
     dependencies:
-      '@babel/code-frame': 7.0.0
+      '@babel/code-frame': 7.5.5
       builtin-modules: 1.1.1
       chalk: 2.4.2
       commander: 2.20.0
@@ -7765,7 +7768,7 @@ packages:
       '@octokit/rest': 16.28.4
       '@types/jju': 1.4.1
       '@types/lodash.once': 4.1.6
-      '@types/node': 12.6.3
+      '@types/node': 12.6.8
       '@types/yargs': 13.0.0
       jju: 1.4.0
       lodash.once: 4.1.1
@@ -7779,12 +7782,23 @@ packages:
       integrity: sha512-INBFn7pX5xucqNGWf1Iz0u1oo9P1Mo6GWKi8WeFdo0RBFr3oaGFVljfGh/K1aFd2awKCBOWFs+OevnhDbrrWPA==
       tarball: 'file:projects/rush-update.tgz'
     version: 0.0.0
+  'file:projects/shift-babel-common.tgz':
+    dependencies:
+      '@babel/types': 7.5.5
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    name: '@rush-temp/shift-babel-common'
+    resolution:
+      integrity: sha512-TOsoyH5Jc/zPZfwr0Ww/atH6w7wBOiN4YmvnR3OAbPMBx90xkd82sTHGbWMwjTyuBXjtop0mPtHViJX27PoKSQ==
+      tarball: 'file:projects/shift-babel-common.tgz'
+    version: 0.0.0
   'file:projects/shift-babel-macro.tgz':
     dependencies:
-      '@babel/parser': 7.5.0
-      '@babel/types': 7.5.0
+      '@babel/parser': 7.5.5
+      '@babel/types': 7.5.5
       '@types/jest': 24.0.15
-      '@types/node': 10.14.12
+      '@types/node': 10.14.13
       babel-plugin-macros: 2.6.1
       babel-plugin-tester: 6.4.0
       jest: 24.8.0
@@ -7794,16 +7808,30 @@ packages:
     dev: false
     name: '@rush-temp/shift-babel-macro'
     resolution:
-      integrity: sha512-03MSQuOXhQNMA1c+kRi2wHs+M6RMw590SzALlnS0RnHietbsOH68yYEDzfSssJfbU6d12qQzNWUAFA6uQbSZIw==
+      integrity: sha512-m/HpCcwcStFbg1l3i6rcoo+VqI32r3IoeVeiocr2Fu7FFwFr5x+Bhr/IMHaUrRO3OYv4PDdi8BOCdKz7XO7y2w==
       tarball: 'file:projects/shift-babel-macro.tgz'
+    version: 0.0.0
+  'file:projects/shift-backend-babel-plugin.tgz':
+    dependencies:
+      '@babel/types': 7.5.5
+      '@types/babel__traverse': 7.0.7
+      babel-plugin-tester: 6.4.0
+      jest: 24.8.0
+      jest-standard-reporter: 1.0.1
+      typescript: 3.5.3
+    dev: false
+    name: '@rush-temp/shift-backend-babel-plugin'
+    resolution:
+      integrity: sha512-2+IfPI7w79T82TxUMyTDaDV2kfOPwfRlnUgvBlXXxlbSyLLTCAWQKlhsb2G83M6mY8HsuxVddmOPMSDgpU+GKA==
+      tarball: 'file:projects/shift-backend-babel-plugin.tgz'
     version: 0.0.0
   'file:projects/shift-db.tgz':
     dependencies:
       '@types/deep-freeze': 0.1.1
       '@types/leveldown': 4.0.0
       '@types/levelup': 3.1.1
-      '@types/node': 10.14.12
-      '@types/ramda': 0.26.15
+      '@types/node': 10.14.13
+      '@types/ramda': 0.26.16
       '@types/rmfr': 2.0.0
       async-mutex: 0.1.3
       ava: 2.1.0
@@ -7833,7 +7861,7 @@ packages:
     version: 0.0.0
   'file:projects/shift-interfaces.tgz':
     dependencies:
-      '@types/node': 10.14.12
+      '@types/node': 10.14.13
       tslint: /tslint/5.18.0/typescript@3.5.3
       typescript: 3.5.3
       typescript-json-schema: 0.38.3
@@ -7845,18 +7873,18 @@ packages:
     version: 0.0.0
   'file:projects/shift-local-proxy.tgz':
     dependencies:
-      '@babel/cli': /@babel/cli/7.5.0/@babel!core@7.5.4
-      '@babel/core': 7.5.4
-      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.4
+      '@babel/cli': /@babel/cli/7.5.5/@babel!core@7.5.5
+      '@babel/core': 7.5.5
+      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.5
       '@types/babel__core': 7.1.2
       '@types/bunyan': 1.8.6
       '@types/express': 4.17.0
-      '@types/got': 9.6.1
+      '@types/got': 9.6.2
       '@types/http-proxy': 1.17.0
       '@types/lodash': 4.14.136
       '@types/mkdirp': 0.5.2
       '@types/nanoid': 2.0.0
-      '@types/node': 10.14.12
+      '@types/node': 10.14.13
       '@types/rimraf': 2.0.2
       ava: 2.1.0
       bunyan: 1.8.12
@@ -7875,7 +7903,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-local-proxy'
     resolution:
-      integrity: sha512-RCA/tlfLqcHkjeVlyBU7hmpw3Dvf1TxsWw3SptxNSKNtKJBzMFfHmyuvg3RdAnd1KQwGfSufXNAFWUUY0jYEKA==
+      integrity: sha512-UjH6E5Tz4dw2J/nZcphLQ8cHgs3RG7wjecWHKi0lj3epHzFdQUVE5Y2xxUma80nhQFvb54TLtMsRxSLm5JWCdA==
       tarball: 'file:projects/shift-local-proxy.tgz'
     version: 0.0.0
   github.com/binaris/nodemon/4900b2d82bcc1b315b1df9bd80817bd86fbe37ed:
@@ -7912,12 +7940,15 @@ specifiers:
   '@babel/types': ^7.5.0
   '@octokit/rest': ^16.28.3
   '@rush-temp/rush-update': 'file:./projects/rush-update.tgz'
+  '@rush-temp/shift-babel-common': 'file:./projects/shift-babel-common.tgz'
   '@rush-temp/shift-babel-macro': 'file:./projects/shift-babel-macro.tgz'
+  '@rush-temp/shift-backend-babel-plugin': 'file:./projects/shift-backend-babel-plugin.tgz'
   '@rush-temp/shift-db': 'file:./projects/shift-db.tgz'
   '@rush-temp/shift-fetch-runtime': 'file:./projects/shift-fetch-runtime.tgz'
   '@rush-temp/shift-interfaces': 'file:./projects/shift-interfaces.tgz'
   '@rush-temp/shift-local-proxy': 'file:./projects/shift-local-proxy.tgz'
   '@types/babel__core': ^7.1.2
+  '@types/babel__traverse': ^7.0.7
   '@types/bunyan': ^1.8.6
   '@types/deep-freeze': ^0.1.1
   '@types/express': ^4.17.0

--- a/rush.json
+++ b/rush.json
@@ -370,7 +370,7 @@
         "shouldPublish": true
     },
     {
-        "packageName": "@binaris/shift-babel-plugin",
+        "packageName": "@binaris/shift-backend-babel-plugin",
         "projectFolder": "babel-plugin",
         "shouldPublish": true
     },
@@ -383,6 +383,6 @@
         "packageName": "rush-update",
         "projectFolder": "tools/rush-update",
         "shouldPublish": true
-    },
+    }
   ]
 }

--- a/rush.json
+++ b/rush.json
@@ -370,9 +370,19 @@
         "shouldPublish": true
     },
     {
+        "packageName": "@binaris/shift-babel-plugin",
+        "projectFolder": "babel-plugin",
+        "shouldPublish": true
+    },
+    {
+        "packageName": "@binaris/shift-babel-common",
+        "projectFolder": "babel-common",
+        "shouldPublish": true
+    },
+    {
         "packageName": "rush-update",
         "projectFolder": "tools/rush-update",
         "shouldPublish": true
-    }
+    },
   ]
 }


### PR DESCRIPTION
Only implements basic exposed functions (no typescript support)

This introduces the first inter-dependency within the shiftjs repo - now any changes to `babel-common/` will publish a new version of `@binaris/shift-babel-common` and new versions of dependants `@binaris/shift-babel-macro` and `@binaris/shift-babel-plugin`. The dependencies are for exact versions so all modules are upgraded in sync.