### PR TITLE
Refer to actual file for types

### DIFF
--- a/common/changes/@binaris/shift-db/types-d-ts_2019-07-17-13-59.json
+++ b/common/changes/@binaris/shift-db/types-d-ts_2019-07-17-13-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-db",
+      "comment": "Properly export types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-db",
+  "email": "ariels@shiftjs.com"
+}

--- a/db/package.json
+++ b/db/package.json
@@ -6,7 +6,7 @@
   ],
   "description": "",
   "main": "dist/index.js",
-  "types": "dist/index.d.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist/ && tsc",
     "lint": "tslint -c ../common/tslint.yml -p .",


### PR DESCRIPTION
As noted in https://github.com/binaris/shiftjs/pull/95#discussion_r304296807, `"types"` looks at a `.d.ts` file ...