### PR TITLE
Cleanup temp directories when ctrl-c is used in terminal 

### DIFF
--- a/common/changes/@binaris/shift-local-proxy/cleanup-sigint_2019-07-18-13-51.json
+++ b/common/changes/@binaris/shift-local-proxy/cleanup-sigint_2019-07-18-13-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-local-proxy",
+      "comment": "Cleanup temp directories on Ctrl-C",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-local-proxy",
+  "email": "vladimir@shiftjs.com"
+}

--- a/local-proxy/src/server.ts
+++ b/local-proxy/src/server.ts
@@ -120,6 +120,12 @@ process.once('SIGUSR2', () => {
   process.kill(process.pid, 'SIGUSR2');
 });
 
+// Handle Ctrl-C in terminal
+process.once('SIGINT', () => {
+  rimraf.sync(tmpDir);
+  process.kill(process.pid, 'SIGINT');
+});
+
 const server = http.createServer(app);
 server.listen(0, '127.0.0.1', () => {
   const { port } = server.address() as AddressInfo;


### PR DESCRIPTION
To avoid confusing leftover .shift_local_proxy_ directories