### PR TITLE
Generate client, server from interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ common/temp/**
 package-deps.json
 
 # Fake generated packages for in-rush development
-interfaces-client/gen/
-interfaces-server/gen/
+interfaces-client/dist/
+interfaces-server/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ dist/
 # Rush files
 common/temp/**
 package-deps.json
+
+# Fake generated packages for in-rush development
+interfaces-client/gen/
+interfaces-server/gen/

--- a/common/changes/@binaris/shift-db/db-interfaces_2019-08-01-12-11.json
+++ b/common/changes/@binaris/shift-db/db-interfaces_2019-08-01-12-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-db",
+      "comment": "Use new interfaces format",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-db",
+  "email": "ariels@shiftjs.com"
+}

--- a/common/changes/@binaris/shift-interfaces/db-interfaces_2019-08-01-12-11.json
+++ b/common/changes/@binaris/shift-interfaces/db-interfaces_2019-08-01-12-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-interfaces",
+      "comment": "Export client, server code using Concord",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@binaris/shift-interfaces",
+  "email": "ariels@shiftjs.com"
+}

--- a/common/changes/@binaris/shift-subscriptions/db-interfaces_2019-08-01-12-11.json
+++ b/common/changes/@binaris/shift-subscriptions/db-interfaces_2019-08-01-12-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-subscriptions",
+      "comment": "Use new interfaces format",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@binaris/shift-subscriptions",
+  "email": "ariels@shiftjs.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -4,6 +4,7 @@ dependencies:
   '@babel/parser': 7.5.5
   '@babel/plugin-transform-modules-commonjs': 7.5.0
   '@babel/types': 7.5.5
+  '@binaris/shift-interfaces': 0.1.1
   '@octokit/rest': 16.28.7
   '@rush-temp/rush-update': 'file:projects/rush-update.tgz'
   '@rush-temp/shift-babel-common': 'file:projects/shift-babel-common.tgz'
@@ -12,6 +13,8 @@ dependencies:
   '@rush-temp/shift-db': 'file:projects/shift-db.tgz'
   '@rush-temp/shift-fetch-runtime': 'file:projects/shift-fetch-runtime.tgz'
   '@rush-temp/shift-interfaces': 'file:projects/shift-interfaces.tgz'
+  '@rush-temp/shift-interfaces-koa-server': 'file:projects/shift-interfaces-koa-server.tgz'
+  '@rush-temp/shift-interfaces-node-client': 'file:projects/shift-interfaces-node-client.tgz'
   '@rush-temp/shift-local-proxy': 'file:projects/shift-local-proxy.tgz'
   '@rush-temp/shift-subscriptions': 'file:projects/shift-subscriptions.tgz'
   '@rush-temp/shiftjs-react-app': 'file:projects/shiftjs-react-app.tgz'
@@ -43,6 +46,7 @@ dependencies:
   babel-plugin-tester: 6.4.0
   bunyan: 1.8.12
   bunyan-rotating-file-stream: 1.6.3
+  concord: 0.2.0
   deep-freeze: 0.0.1
   express: 4.17.1
   fast-json-patch: 2.2.0
@@ -69,7 +73,6 @@ dependencies:
   sinon: 7.3.2
   tslint: 5.18.0
   typescript: 3.5.3
-  typescript-json-schema: 0.39.0
   walkdir: 0.4.1
   yargs: 13.3.0
 packages:
@@ -406,6 +409,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  /@binaris/shift-interfaces/0.1.1:
+    dependencies:
+      fast-json-patch: 2.2.0
+    dev: false
+    resolution:
+      integrity: sha512-2zpWcQt+OLoG3ej7yGZrCky/PU/2M5GiQrSGQCuHslq8y9vQi0jsbotJ0yYvjIrJ3GaYb5AuyjPIuf0L5HN6BA==
   /@cnakazawa/watch/1.0.3:
     dependencies:
       exec-sh: 0.3.2
@@ -1100,6 +1109,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-8zjUtFJ3db/QoPXuuEMloS2AUf79/yeyttJ7Abr3hteopJu9HK8vsgGviGUMq+zyA6cZZO6gAyZoMTF6TgaEjA==
+  /any-promise/1.3.0:
+    dev: false
+    resolution:
+      integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=
   /anymatch/2.0.0:
     dependencies:
       micromatch: 3.1.10
@@ -2060,6 +2073,21 @@ packages:
       '0': node >= 0.8
     resolution:
       integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  /concord/0.2.0:
+    dependencies:
+      glob: 7.1.4
+      lodash: 4.17.15
+      mustache: 3.0.1
+      mz: 2.7.0
+      npm: 6.10.2
+      rmfr: 2.0.0
+      typescript: 3.5.3
+      typescript-json-schema: 0.39.0
+      yargs: 13.3.0
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-6y4S7yEyYi1f2zfHe9obwxQvsOr6HEG/QVJu0438Wm9UkPpFDhRlTlCtpoBeu7qieH7m9E9dnR/F9t9+RMNUEA==
   /concordance/4.0.0:
     dependencies:
       date-time: 2.1.0
@@ -5214,6 +5242,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+  /mustache/3.0.1:
+    dev: false
+    engines:
+      npm: '>=1.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==
   /mv/2.1.1:
     dependencies:
       mkdirp: 0.5.1
@@ -5225,6 +5260,14 @@ packages:
     optional: true
     resolution:
       integrity: sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  /mz/2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+    dev: false
+    resolution:
+      integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
   /nan/2.14.0:
     dev: false
     optional: true
@@ -5455,6 +5498,135 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+  /npm/6.10.2:
+    bundledDependencies:
+      - abbrev
+      - ansicolors
+      - ansistyles
+      - aproba
+      - archy
+      - bin-links
+      - bluebird
+      - byte-size
+      - cacache
+      - call-limit
+      - chownr
+      - ci-info
+      - cli-columns
+      - cli-table3
+      - cmd-shim
+      - columnify
+      - config-chain
+      - debuglog
+      - detect-indent
+      - detect-newline
+      - dezalgo
+      - editor
+      - figgy-pudding
+      - find-npm-prefix
+      - fs-vacuum
+      - fs-write-stream-atomic
+      - gentle-fs
+      - glob
+      - graceful-fs
+      - has-unicode
+      - hosted-git-info
+      - iferr
+      - imurmurhash
+      - infer-owner
+      - inflight
+      - inherits
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-better-errors
+      - JSONStream
+      - lazy-property
+      - libcipm
+      - libnpm
+      - libnpmaccess
+      - libnpmhook
+      - libnpmorg
+      - libnpmsearch
+      - libnpmteam
+      - libnpx
+      - lock-verify
+      - lockfile
+      - lodash._baseindexof
+      - lodash._baseuniq
+      - lodash._bindcallback
+      - lodash._cacheindexof
+      - lodash._createcache
+      - lodash._getnative
+      - lodash.clonedeep
+      - lodash.restparam
+      - lodash.union
+      - lodash.uniq
+      - lodash.without
+      - lru-cache
+      - meant
+      - mississippi
+      - mkdirp
+      - move-concurrently
+      - node-gyp
+      - nopt
+      - normalize-package-data
+      - npm-audit-report
+      - npm-cache-filename
+      - npm-install-checks
+      - npm-lifecycle
+      - npm-package-arg
+      - npm-packlist
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - npmlog
+      - once
+      - opener
+      - osenv
+      - pacote
+      - path-is-inside
+      - promise-inflight
+      - qrcode-terminal
+      - query-string
+      - qw
+      - read-cmd-shim
+      - read-installed
+      - read-package-json
+      - read-package-tree
+      - read
+      - readable-stream
+      - readdir-scoped-modules
+      - request
+      - retry
+      - rimraf
+      - safe-buffer
+      - semver
+      - sha
+      - slide
+      - sorted-object
+      - sorted-union-stream
+      - ssri
+      - stringify-package
+      - tar
+      - text-table
+      - tiny-relative-date
+      - uid-number
+      - umask
+      - unique-filename
+      - unpipe
+      - update-notifier
+      - uuid
+      - validate-npm-package-license
+      - validate-npm-package-name
+      - which
+      - worker-farm
+      - write-file-atomic
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-B6n5dgmsl1fpBYhor2OTEn9Md0r63/FpQocDn4WNT4gIQRQZLql9g+mk8s3j9qZD370kUTzwDaOBSmDdNGK3NA==
   /number-is-nan/1.0.1:
     dev: false
     engines:
@@ -7241,6 +7413,20 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
+  /thenify-all/1.6.0:
+    dependencies:
+      thenify: 3.3.0
+    dev: false
+    engines:
+      node: '>=0.8'
+    resolution:
+      integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  /thenify/3.3.0:
+    dependencies:
+      any-promise: 1.3.0
+    dev: false
+    resolution:
+      integrity: sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
   /throat/4.1.0:
     dev: false
     resolution:
@@ -8091,7 +8277,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-db'
     resolution:
-      integrity: sha512-oEEsesqYPQYqVSeC5c8CbjqA2RvMGv677NX8FHumFZLsNekPoDSMxYSUa+9D/eFn6dkhEemHD5DireZDXHgEjw==
+      integrity: sha512-THqY21acMTxk3z9oxVbJ+eFO9J1kZ9ScNbpKsfED/CBT2hRQN0iy1oyfajZnfFu02Ump/NVx+sB4dhTnlD2LGA==
       tarball: 'file:projects/shift-db.tgz'
     version: 0.0.0
   'file:projects/shift-fetch-runtime.tgz':
@@ -8104,17 +8290,39 @@ packages:
       integrity: sha512-4fjRMYNdUQ3w6VMzkT/0PMknschpGaK6gnRjeb01129Y91Dk8jRC7VGwxI5Yk60lw2NH1VsGM+qpcjfO8LZCIA==
       tarball: 'file:projects/shift-fetch-runtime.tgz'
     version: 0.0.0
+  'file:projects/shift-interfaces-koa-server.tgz':
+    dependencies:
+      '@types/node': 10.14.14
+      concord: 0.2.0
+      typescript: 3.5.3
+    dev: false
+    name: '@rush-temp/shift-interfaces-koa-server'
+    resolution:
+      integrity: sha512-/hOgX7hSc6XrCpSQtBTGIGko70bFqhjNzurlp/QDIVTy6S4Sxf4sh8FVy79LbZKdXYOIpqovyE5ouOiSNHAunQ==
+      tarball: 'file:projects/shift-interfaces-koa-server.tgz'
+    version: 0.0.0
+  'file:projects/shift-interfaces-node-client.tgz':
+    dependencies:
+      '@types/node': 10.14.14
+      concord: 0.2.0
+      typescript: 3.5.3
+    dev: false
+    name: '@rush-temp/shift-interfaces-node-client'
+    resolution:
+      integrity: sha512-PmaZxKRnV2VCF9jSf38KUQqpOzCOPKoyhav5QgXk5rJZoS0S0bz0nC/ytzSfxkKgyjXAJTvZ0oSXxjfMqGUCfA==
+      tarball: 'file:projects/shift-interfaces-node-client.tgz'
+    version: 0.0.0
   'file:projects/shift-interfaces.tgz':
     dependencies:
       '@types/node': 10.14.14
+      concord: 0.2.0
       fast-json-patch: 2.2.0
       tslint: /tslint/5.18.0/typescript@3.5.3
       typescript: 3.5.3
-      typescript-json-schema: 0.39.0
     dev: false
     name: '@rush-temp/shift-interfaces'
     resolution:
-      integrity: sha512-ZuOKGABbfUejgxf1lvz2HJKGdDdRoYhie1NWtFxbjteTCtCQtlvcCGLA9JM4EWZq85lkM9DjrYKtLu6HJ4y4Bg==
+      integrity: sha512-OM1fLTMOkkgyyjUPU6D/dlTnYPZLFiiDkuwAMwfMlNaOykAdtsx9Tj6JwrF47BAqnFEmtXNpvvfxLS7jBXh0og==
       tarball: 'file:projects/shift-interfaces.tgz'
     version: 0.0.0
   'file:projects/shift-local-proxy.tgz':
@@ -8154,6 +8362,7 @@ packages:
     version: 0.0.0
   'file:projects/shift-subscriptions.tgz':
     dependencies:
+      '@binaris/shift-interfaces': 0.1.1
       '@types/node': 10.14.14
       '@types/react': 16.8.24
       '@types/sinon': 7.0.13
@@ -8169,7 +8378,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-subscriptions'
     resolution:
-      integrity: sha512-NBbvkvQsIuOmoNMBeOCLOgoisGlnE0Z9GSBRTw4Cm0/ZZyjHU0/Hl5hBSfLwHO0Lz8Y2Ba3iVOnDHIxaixwP/g==
+      integrity: sha512-yew1rhGMMKmQG2NdpV2bQPMtOxA/cZLd9lfYXETe08A0QjmVwWqQlcyDEjEctgErlX5WkdRp8YQk2yDF3yxncQ==
       tarball: 'file:projects/shift-subscriptions.tgz'
     version: 0.0.0
   'file:projects/shiftjs-react-app.tgz':
@@ -8220,6 +8429,7 @@ specifiers:
   '@babel/parser': ^7.5.5
   '@babel/plugin-transform-modules-commonjs': ^7.5.0
   '@babel/types': ^7.5.5
+  '@binaris/shift-interfaces': 0.1.1
   '@octokit/rest': ^16.28.7
   '@rush-temp/rush-update': 'file:./projects/rush-update.tgz'
   '@rush-temp/shift-babel-common': 'file:./projects/shift-babel-common.tgz'
@@ -8228,6 +8438,8 @@ specifiers:
   '@rush-temp/shift-db': 'file:./projects/shift-db.tgz'
   '@rush-temp/shift-fetch-runtime': 'file:./projects/shift-fetch-runtime.tgz'
   '@rush-temp/shift-interfaces': 'file:./projects/shift-interfaces.tgz'
+  '@rush-temp/shift-interfaces-koa-server': 'file:./projects/shift-interfaces-koa-server.tgz'
+  '@rush-temp/shift-interfaces-node-client': 'file:./projects/shift-interfaces-node-client.tgz'
   '@rush-temp/shift-local-proxy': 'file:./projects/shift-local-proxy.tgz'
   '@rush-temp/shift-subscriptions': 'file:./projects/shift-subscriptions.tgz'
   '@rush-temp/shiftjs-react-app': 'file:./projects/shiftjs-react-app.tgz'
@@ -8259,6 +8471,7 @@ specifiers:
   babel-plugin-tester: ^6.4.0
   bunyan: ^1.8.12
   bunyan-rotating-file-stream: ^1.6.3
+  concord: ~0.2.0
   deep-freeze: ^0.0.1
   express: ^4.17.1
   fast-json-patch: ^2.2.0
@@ -8285,6 +8498,5 @@ specifiers:
   sinon: ^7.3.2
   tslint: ^5.18.0
   typescript: ^3.5.3
-  typescript-json-schema: ^0.39.0
   walkdir: ^0.4.1
   yargs: ^13.3.0

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -4,7 +4,6 @@ dependencies:
   '@babel/parser': 7.5.5
   '@babel/plugin-transform-modules-commonjs': 7.5.0
   '@babel/types': 7.5.5
-  '@binaris/shift-interfaces': 0.1.1
   '@octokit/rest': 16.28.7
   '@rush-temp/rush-update': 'file:projects/rush-update.tgz'
   '@rush-temp/shift-babel-common': 'file:projects/shift-babel-common.tgz'
@@ -409,12 +408,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
-  /@binaris/shift-interfaces/0.1.1:
-    dependencies:
-      fast-json-patch: 2.2.0
-    dev: false
-    resolution:
-      integrity: sha512-2zpWcQt+OLoG3ej7yGZrCky/PU/2M5GiQrSGQCuHslq8y9vQi0jsbotJ0yYvjIrJ3GaYb5AuyjPIuf0L5HN6BA==
   /@cnakazawa/watch/1.0.3:
     dependencies:
       exec-sh: 0.3.2
@@ -8362,7 +8355,6 @@ packages:
     version: 0.0.0
   'file:projects/shift-subscriptions.tgz':
     dependencies:
-      '@binaris/shift-interfaces': 0.1.1
       '@types/node': 10.14.14
       '@types/react': 16.8.24
       '@types/sinon': 7.0.13
@@ -8378,7 +8370,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-subscriptions'
     resolution:
-      integrity: sha512-yew1rhGMMKmQG2NdpV2bQPMtOxA/cZLd9lfYXETe08A0QjmVwWqQlcyDEjEctgErlX5WkdRp8YQk2yDF3yxncQ==
+      integrity: sha512-kwKW3YoP3ScF0CVcq20P9NY85zbUuilvp6etyDksRHkrosqUr29sHwUL4b397Yof3AH/RiG12BJpnJdLexdbaQ==
       tarball: 'file:projects/shift-subscriptions.tgz'
     version: 0.0.0
   'file:projects/shiftjs-react-app.tgz':
@@ -8429,7 +8421,6 @@ specifiers:
   '@babel/parser': ^7.5.5
   '@babel/plugin-transform-modules-commonjs': ^7.5.0
   '@babel/types': ^7.5.5
-  '@binaris/shift-interfaces': 0.1.1
   '@octokit/rest': ^16.28.7
   '@rush-temp/rush-update': 'file:./projects/rush-update.tgz'
   '@rush-temp/shift-babel-common': 'file:./projects/shift-babel-common.tgz'

--- a/db/package.json
+++ b/db/package.json
@@ -15,7 +15,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@binaris/shift-interfaces": "0.1.2",
+    "@binaris/shift-interfaces": "0.2.0-rc.0",
+    "@binaris/shift-interfaces-koa-server": "0.2.0-rc.0",
+    "@binaris/shift-interfaces-node-client": "0.2.0-rc.0",
     "@types/deep-freeze": "^0.1.1",
     "@types/leveldown": "^4.0.0",
     "@types/levelup": "^3.1.1",

--- a/db/src/db.ts
+++ b/db/src/db.ts
@@ -9,9 +9,12 @@ import {
   UpdateOptions,
   Version,
   Versioned,
-  Patch,
   KeyedPatches,
 } from '@binaris/shift-interfaces/dist/subscriptions';
+import {
+  Patch,
+  Serializable,
+} from '@binaris/shift-interfaces-node-client/gen/interfaces';
 import { ValueError } from './errors';
 import * as Q from './query';
 import { withTimeout, deferred, hrnano } from './utils';
@@ -22,14 +25,11 @@ export {
   Versioned,
   KeyedPatches,
   UpdateOptions,
+  Serializable,
 };
 
 const NUM_PATCHES_TO_KEEP = 20;
 const DEFAULT_READ_BLOCK_TIME_MS = 50000;
-
-// Typescript's way of defining any - undefined
-// see: https://github.com/Microsoft/TypeScript/issues/7648
-export type Serializable = {} | null;
 
 export function incrVersion([x, y]: Version, amount: number = 1): Version {
   return [x, y + amount];

--- a/db/src/db.ts
+++ b/db/src/db.ts
@@ -5,16 +5,16 @@ import { compare } from 'fast-json-patch';
 import LevelUpCtor, { LevelUp } from 'levelup';
 import LevelDown from 'leveldown';
 import { Mutex } from 'async-mutex';
+import { Version } from '@binaris/shift-interfaces/dist/db';
 import {
   UpdateOptions,
-  Version,
   Versioned,
   KeyedPatches,
 } from '@binaris/shift-interfaces/dist/subscriptions';
 import {
   Patch,
   Serializable,
-} from '@binaris/shift-interfaces-node-client/gen/interfaces';
+} from '@binaris/shift-interfaces-node-client/dist/interfaces';
 import { ValueError } from './errors';
 import * as Q from './query';
 import { withTimeout, deferred, hrnano } from './utils';

--- a/interfaces-client/README.md
+++ b/interfaces-client/README.md
@@ -1,0 +1,13 @@
+# What's this?
+
+A minimal *fake* wrapper package for generated code.  `interfaces`
+uses [Concord](https://github.com/concord) to write typed client and
+server codes.
+
+rush doesn't like gnerate entire packages.  These wrappers (one for
+server code, one for client code) generate and export these packages
+as part of their build step -- but they _already_ look enough like the
+finished packages to allow rush to function.
+
+To prevent accidental publication these fake packages are "private".
+The *real* packages are not.

--- a/interfaces-client/package.json
+++ b/interfaces-client/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@binaris/shift-interfaces-node-client",
+  "private": true,
+  "version": "0.2.0-rc.0",
+  "files": [
+    "gen/"
+  ],
+  "description": "fake client interfaces wrapper",
+  "main": "gen/client.js",
+  "types": "gen/client.d.ts",
+  "scripts": {
+    "build": "npm run really-build",
+    "really-build": "rm -fr gen/ && concord 2>&1 --allow-extra-props node --client fetch -o gen ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
+    "lint": "echo generated client does not lint",
+    "test": "echo generated client needs no tests"
+  },
+  "devDependencies": {
+    "@binaris/shift-interfaces": "~0.2.0-rc.0",
+    "@types/node": "^10.14.9",
+    "concord": "~0.2.0",
+    "typescript": "^3.5.3"
+  },
+  "author": "Future Concord Piskie",
+  "repository": "undefined",
+  "license": "MIT"
+}

--- a/interfaces-client/package.json
+++ b/interfaces-client/package.json
@@ -3,21 +3,21 @@
   "private": true,
   "version": "0.2.0-rc.0",
   "files": [
-    "gen/"
+    "dist/"
   ],
   "description": "fake client interfaces wrapper",
-  "main": "gen/client.js",
-  "types": "gen/client.d.ts",
+  "main": "dist/client.js",
+  "types": "dist/client.d.ts",
   "scripts": {
     "build": "npm run really-build",
-    "really-build": "rm -fr gen/ && concord 2>&1 --allow-extra-props node --client fetch -o gen ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
+    "really-build": "rm -fr dist/ && concord 2>&1 --allow-extra-props node --client fetch -o dist ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
     "lint": "echo generated client does not lint",
     "test": "echo generated client needs no tests"
   },
   "devDependencies": {
     "@binaris/shift-interfaces": "~0.2.0-rc.0",
     "@types/node": "^10.14.9",
-    "concord": "~0.2.0",
+    "concord": "^0.2.0",
     "typescript": "^3.5.3"
   },
   "author": "Future Concord Piskie",

--- a/interfaces-server/README.md
+++ b/interfaces-server/README.md
@@ -1,0 +1,1 @@
+../interfaces-client/README.md

--- a/interfaces-server/package.json
+++ b/interfaces-server/package.json
@@ -3,21 +3,21 @@
   "private": true,
   "version": "0.2.0-rc.0",
   "files": [
-    "gen/"
+    "dist/"
   ],
   "description": "fake server interfaces wrapper",
-  "main": "gen/server.js",
-  "types": "gen/server.d.ts",
+  "main": "dist/server.js",
+  "types": "dist/server.d.ts",
   "scripts": {
     "build": "npm run really-build",
-    "really-build": "rm -fr gen/ && concord 2>&1 --allow-extra-props node --server koa -o gen ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
+    "really-build": "rm -fr dist/ && concord 2>&1 node --server koa -o dist ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
     "lint": "echo generated server does not lint",
     "test": "echo generated server needs no tests"
  },
   "devDependencies": {
     "@binaris/shift-interfaces": "~0.2.0-rc.0",
     "@types/node": "^10.14.9",
-    "concord": "~0.2.0",
+    "concord": "^0.2.0",
     "typescript": "^3.5.3"
   },
   "author": "Future Concord Piskie",

--- a/interfaces-server/package.json
+++ b/interfaces-server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@binaris/shift-interfaces-koa-server",
+  "private": true,
+  "version": "0.2.0-rc.0",
+  "files": [
+    "gen/"
+  ],
+  "description": "fake server interfaces wrapper",
+  "main": "gen/server.js",
+  "types": "gen/server.d.ts",
+  "scripts": {
+    "build": "npm run really-build",
+    "really-build": "rm -fr gen/ && concord 2>&1 --allow-extra-props node --server koa -o gen ${npm_package_name}@${npm_package_version} ../interfaces/src/*.ts",
+    "lint": "echo generated server does not lint",
+    "test": "echo generated server needs no tests"
+ },
+  "devDependencies": {
+    "@binaris/shift-interfaces": "~0.2.0-rc.0",
+    "@types/node": "^10.14.9",
+    "concord": "~0.2.0",
+    "typescript": "^3.5.3"
+  },
+  "author": "Future Concord Piskie",
+  "repository": "undefined",
+  "license": "MIT"
+}

--- a/interfaces/package.json
+++ b/interfaces/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@binaris/shift-interfaces",
   "version": "0.1.2",
+  "version": "0.2.0-rc.0",
   "files": [
-    "dist"
+    "dist/"
   ],
   "description": "interfaces for serving ShiftJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist/ && tsc && npm run compile-schema",
-    "compile-schema": "typescript-json-schema -o dist/schema.json --required --noExtraProps tsconfig.json '*'",
+    "build": "rm -rf dist/ && tsc",
     "lint": "tslint -c ../common/tslint.yml -p .",
-    "test": "echo interface needs no tests"
+    "test": "echo interface needs no tests",
+    "build-koa-server": "rm -fr gen-server/ && concord node --server koa -o gen-server ${npm_package_name}-koa-server@${npm_package_version} src/index.ts",
+    "build-node-client": "rm -fr gen-client/ && concord --allow-extra-props node --client fetch -o gen-client ${npm_package_name}-node-client@${npm_package_version} src/index.ts"
   },
   "author": "",
   "license": "MIT",
@@ -20,8 +22,8 @@
   },
   "devDependencies": {
     "@types/node": "^10.14.9",
+    "concord": "~0.2.0",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3",
-    "typescript-json-schema": "^0.39.0"
+    "typescript": "^3.5.3"
   }
 }

--- a/interfaces/src/db.ts
+++ b/interfaces/src/db.ts
@@ -116,7 +116,7 @@ interface Patches {
   /**
    * Stores changes made to the document, meant to be used internally by poll().
    */
-  patches: ReadonlyArray<Patch>;
+  patches: Patch[];
   updatedAt: number;
 }
 

--- a/interfaces/src/subscriptions.ts
+++ b/interfaces/src/subscriptions.ts
@@ -1,6 +1,6 @@
 import { Operation } from 'fast-json-patch';
 
-export type Version = [number, number];
+import { Version } from './db';
 
 export interface UpdateOptions {
   /**

--- a/interfaces/src/subscriptions.ts
+++ b/interfaces/src/subscriptions.ts
@@ -1,5 +1,7 @@
 import { Operation } from 'fast-json-patch';
 
+export type Version = [number, number];
+
 export interface UpdateOptions {
   /**
    * Used to mark an update originated from a specific operation (useful for optimistic UI).
@@ -7,8 +9,6 @@ export interface UpdateOptions {
    */
   readonly operationId?: string;
 }
-
-export type Version = [number, number];
 
 export interface Versioned<T> {
   /**

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.9.1",
+  "rushVersion": "5.11.1",
 
   /**
    * The next field selects which package manager should be installed and determines its version.
@@ -368,6 +368,16 @@
         "packageName": "@binaris/shift-interfaces",
         "projectFolder": "interfaces",
         "shouldPublish": true
+    },
+    {
+        "packageName": "@binaris/shift-interfaces-node-client",
+        "projectFolder": "interfaces-client",
+        "shouldPublish": false
+    },
+    {
+        "packageName": "@binaris/shift-interfaces-koa-server",
+        "projectFolder": "interfaces-server",
+        "shouldPublish": false
     },
     {
         "packageName": "@binaris/shift-backend-babel-plugin",

--- a/subscriptions/package.json
+++ b/subscriptions/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "@binaris/shift-fetch-runtime": "0.0.3",
-    "@binaris/shift-interfaces": "0.1.2",
+    "@binaris/shift-interfaces": "0.2.0-rc.0",
+    "@binaris/shift-interfaces": "0.1.1",
     "fast-json-patch": "^2.2.0",
     "immutable": "^4.0.0-rc.12",
     "react": "^16.8.6",

--- a/subscriptions/package.json
+++ b/subscriptions/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@binaris/shift-fetch-runtime": "0.0.3",
     "@binaris/shift-interfaces": "0.2.0-rc.0",
-    "@binaris/shift-interfaces": "0.1.1",
     "fast-json-patch": "^2.2.0",
     "immutable": "^4.0.0-rc.12",
     "react": "^16.8.6",

--- a/subscriptions/src/subscriptions.ts
+++ b/subscriptions/src/subscriptions.ts
@@ -15,10 +15,10 @@ import {
   share,
 } from 'rxjs/operators';
 import { applyReducer, Operation } from 'fast-json-patch';
+import { Version } from '@binaris/shift-interfaces/dist/db';
 import {
   KeyedPatches,
   Patch,
-  Version,
   Versioned,
 } from '@binaris/shift-interfaces/dist/subscriptions';
 import { mapWithState, StateAndOutput, takeUntilLast } from './rxutils';

--- a/subscriptions/src/test/subscriptions.spec.ts
+++ b/subscriptions/src/test/subscriptions.spec.ts
@@ -3,7 +3,8 @@ import * as im from 'immutable';
 import { stub } from 'sinon';
 import { concat, EMPTY, NEVER, of, Subject } from 'rxjs';
 import { delay, take, tap, toArray } from 'rxjs/operators';
-import { Patch, Version } from '@binaris/shift-interfaces/dist/subscriptions';
+import { Version } from '@binaris/shift-interfaces/dist/db';
+import { Patch } from '@binaris/shift-interfaces/dist/subscriptions';
 import {
   DEREGISTER,
   NonEmptyArray,


### PR DESCRIPTION
# ⚠️ This is an interim solution!
    
Rush and Concord do not play nicely together.  Create *fake* packages
for client and server definitions: `interfaces-{client,server}` link
during `rush update` as though they were the real thing, but after
build they forward to the generated code.
    
Problems include that dependencies from the generated code are not
propagated; we shall have to copy the really-required ones out from
`interfaces-{client,server}/gen/package.json` up to
`interfaces-{client,server}/package.json`.
    
# ⚠️ This is an interim solution!
    
The right way to do it may be to change Concord to support building a
package from inside it.
