### PR TITLE
Ignore publish- branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,16 +81,34 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                # according to https://circleci.com/docs/2.0/configuration-reference/#filters-1
+                # regex should capture the whole string, so not /^publish-/
+                - /publish-.*/
       - lint:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - /publish-.*/
       - test:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - /publish-.*/
       - verify_change_logs:
           requires:
             - build
+          filters:
+            branches:
+              ignore:
+                - /publish-.*/
   weekly:
     triggers:
        - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ workflows:
   commit:
     jobs:
       - build:
-          filters:
+          filters: &ignore_publish
             branches:
               ignore:
                 # according to https://circleci.com/docs/2.0/configuration-reference/#filters-1
@@ -91,24 +91,15 @@ workflows:
       - lint:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - /publish-.*/
+          filters: *ignore_publish
       - test:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - /publish-.*/
+          filters: *ignore_publish
       - verify_change_logs:
           requires:
             - build
-          filters:
-            branches:
-              ignore:
-                - /publish-.*/
+          filters: *ignore_publish
   weekly:
     triggers:
        - schedule:


### PR DESCRIPTION
Publish branches are temporarily created by rush during publish process
before being merged into the master branch
By the time circleci starts processing the branch it is already deleted,
causing noisy errors in logs

For some reason `yq` breaks on the `jobs` section `.circleci/config.yml`, tested with`$ js-yaml .circleci/config.yml`.