### PR TITLE
Increase install test timeout

### DIFF
--- a/common/changes/@binaris/shiftjs-react-app/moar-timeout_2019-08-08-10-59.json
+++ b/common/changes/@binaris/shiftjs-react-app/moar-timeout_2019-08-08-10-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@binaris/shiftjs-react-app",
+      "type": "none"
+    }
+  ],
+  "packageName": "@binaris/shiftjs-react-app",
+  "email": "vladimir@shiftjs.com"
+}

--- a/shiftjs-react-app/src/test/shiftReactApp.spec.ts
+++ b/shiftjs-react-app/src/test/shiftReactApp.spec.ts
@@ -111,7 +111,7 @@ test('install creates node_modules', async () => {
   expect(msg).toBe(`Packages installed
 Modified package.json, please commit this file`);
   await promiseAccess('node_modules');
-}, 60000);
+}, 180000);
 
 test('ignore does not create .gitignore', async () => {
   await fakeApp();


### PR DESCRIPTION
Installing all create-react-app packages from npm takes a varying time,
sometimes going above 60 seconds