### PR TITLE
Use non-strict parsing when parsing BaseCommand flags

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -64,7 +64,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.0/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
 
 ## `shift-cli logs`
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -50,6 +50,7 @@
     "@oclif/parser": "^3.8.4",
     "@oclif/plugin-help": "^2.2.0",
     "@oclif/plugin-not-found": "^1.2.2",
+    "chalk": "^2.4.2",
     "cli-ux": "^5.3.1",
     "conf": "^5.0.0",
     "dotenv": "^8.0.0",

--- a/cli/src/commands/logs.ts
+++ b/cli/src/commands/logs.ts
@@ -45,6 +45,8 @@ $ ${Command.cliBinName} logs --since 2m --follow`,
 
   public static args = [];
 
+  public static strict = true;
+
   public async run() {
 
     const {flags: { since, follow, limit }} = this.parse(Logs);

--- a/cli/src/utils/command.ts
+++ b/cli/src/utils/command.ts
@@ -66,7 +66,7 @@ export default abstract class BaseCommand extends Command {
       opt.flags = BaseCommand.flags;
     }
 
-    return Parser.parse(argv, { context: this, ...opt });
+    return Parser.parse(argv, { context: this, ...opt, strict: false });
   }
 
   public async init() {

--- a/cli/src/utils/command.ts
+++ b/cli/src/utils/command.ts
@@ -66,7 +66,7 @@ export default abstract class BaseCommand extends Command {
       opt.flags = BaseCommand.flags;
     }
 
-    return Parser.parse(argv, { context: this, ...opt, strict: false });
+    return Parser.parse(argv, { context: this, strict: false, ...opt });
   }
 
   public async init() {

--- a/common/changes/shift-cli/cli-fix-parsing_2019-08-15-15-30.json
+++ b/common/changes/shift-cli/cli-fix-parsing_2019-08-15-15-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "shift-cli",
+      "comment": "Fix parsing of base command flags",
+      "type": "patch"
+    }
+  ],
+  "packageName": "shift-cli",
+  "email": "vladimir@shiftjs.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -66,6 +66,7 @@ dependencies:
   babel-plugin-tester: 6.4.0
   bunyan: 1.8.12
   bunyan-rotating-file-stream: 1.6.3
+  chalk: 2.4.2
   cli-ux: 5.3.1
   conf: 5.0.0
   deep-freeze: 0.0.1
@@ -155,27 +156,6 @@ packages:
       source-map: 0.5.7
     dev: false
     hasBin: true
-    optionalDependencies:
-      chokidar: 2.1.6
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-UHI+7pHv/tk9g6WXQKYz+kmXTI77YtuY3vqC59KIqcoWEjsJJSG6rAxKaLsgj3LDyadsPrCB929gVOKM6Hui0w==
-  /@babel/cli/7.5.5/@babel!core@7.5.5:
-    dependencies:
-      '@babel/core': 7.5.5
-      commander: 2.20.0
-      convert-source-map: 1.6.0
-      fs-readdir-recursive: 1.1.0
-      glob: 7.1.4
-      lodash: 4.17.15
-      mkdirp: 0.5.1
-      output-file-sync: 2.0.1
-      slash: 2.0.0
-      source-map: 0.5.7
-    dev: false
-    hasBin: true
-    id: registry.npmjs.org/@babel/cli/7.5.5
     optionalDependencies:
       chokidar: 2.1.6
     peerDependencies:
@@ -401,7 +381,6 @@ packages:
       integrity: sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==
   /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.5:
     dependencies:
-      '@babel/core': 7.5.5
       '@babel/helper-module-transforms': 7.5.5
       '@babel/helper-plugin-utils': 7.0.0
       '@babel/helper-simple-access': 7.1.0
@@ -498,12 +477,35 @@ packages:
       typescript: '>= 3.0.1 || >= 3.3.0-dev || >= 3.4.0-dev'
     resolution:
       integrity: sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==
+  /@fimbul/bifrost/0.17.0/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      '@fimbul/ymir': /@fimbul/ymir/0.17.0/tsutils@3.17.1+typescript@3.5.3
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      tsutils: /tsutils/3.17.1/typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    id: registry.npmjs.org/@fimbul/bifrost/0.17.0
+    peerDependencies:
+      tslint: ^5.0.0
+      typescript: '>= 3.0.1 || >= 3.3.0-dev || >= 3.4.0-dev'
+    resolution:
+      integrity: sha512-gVTkJAOef5HtN6LPmrtt5fAUmBywwlgmObsU3FBhPoNeXPLaIl2zywXkJEtvvVLQnaFmtff3x+wIj5lHRCDE3Q==
   /@fimbul/ymir/0.17.0/tsutils@3.17.1:
     dependencies:
       inversify: 5.0.1
       reflect-metadata: 0.1.13
       tslib: 1.10.0
-      tsutils: 3.17.1
+    dev: false
+    id: registry.npmjs.org/@fimbul/ymir/0.17.0
+    peerDependencies:
+      tsutils: '>=2.29.0'
+      typescript: '>= 3.0.1 || >= 3.3.0-dev || >= 3.4.0-dev'
+    resolution:
+      integrity: sha512-xMXM9KTXRLHLVS6dnX1JhHNEkmWHcAVCQ/4+DA1KKwC/AFnGHzu/7QfQttEPgw3xplT+ILf9e3i64jrFwB3JtA==
+  /@fimbul/ymir/0.17.0/tsutils@3.17.1+typescript@3.5.3:
+    dependencies:
+      tsutils: /tsutils/3.17.1/typescript@3.5.3
+      typescript: 3.5.3
     dev: false
     id: registry.npmjs.org/@fimbul/ymir/0.17.0
     peerDependencies:
@@ -810,6 +812,16 @@ packages:
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
+  /@oclif/tslint/3.1.1/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      tslint-eslint-rules: /tslint-eslint-rules/5.4.0/tslint@5.18.0+typescript@3.5.3
+      tslint-xo: /tslint-xo/0.9.0/tslint@5.18.0+typescript@3.5.3
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    id: registry.npmjs.org/@oclif/tslint/3.1.1
     resolution:
       integrity: sha512-B1ZWbgzwxDhNZLzVnn+JjyFf9u+J9wNwsz/ZX9YvA9edRYcdiJz9JikCttGPi35V0NU0TUV4UqTqo/q/wQ06jQ==
   /@octokit/endpoint/5.3.2:
@@ -8387,12 +8399,37 @@ packages:
       typescript: '>=2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev || >=3.4.0-dev'
     resolution:
       integrity: sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==
+  /tslint-consistent-codestyle/1.15.1/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      '@fimbul/bifrost': /@fimbul/bifrost/0.17.0/tslint@5.18.0+typescript@3.5.3
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      tsutils: /tsutils/2.29.0/typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    id: registry.npmjs.org/tslint-consistent-codestyle/1.15.1
+    peerDependencies:
+      tslint: ^5.0.0
+      typescript: '>=2.1.4 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >=3.1.0-dev || >=3.2.0-dev || >=3.3.0-dev || >=3.4.0-dev'
+    resolution:
+      integrity: sha512-38Y3Dz4zcABe/PlPAQSGNEWPGVq0OzcIQR7SEU6dNujp/SgvhxhJOhIhI9gY4r0I3/TNtvVQwARWor9O9LPZWg==
   /tslint-eslint-rules/5.4.0:
     dependencies:
       doctrine: 0.7.2
       tslib: 1.9.0
       tsutils: 3.17.1
     dev: false
+    peerDependencies:
+      tslint: ^5.0.0
+      typescript: ^2.2.0 || ^3.0.0
+    resolution:
+      integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
+  /tslint-eslint-rules/5.4.0/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      tsutils: /tsutils/3.17.1/typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    id: registry.npmjs.org/tslint-eslint-rules/5.4.0
     peerDependencies:
       tslint: ^5.0.0
       typescript: ^2.2.0 || ^3.0.0
@@ -8407,6 +8444,18 @@ packages:
       typescript: ^2.1.0 || ^3.0.0
     resolution:
       integrity: sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
+  /tslint-microsoft-contrib/5.2.1/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      tsutils: /tsutils/2.28.0/typescript@3.5.3
+      typescript: 3.5.3
+    dev: false
+    id: registry.npmjs.org/tslint-microsoft-contrib/5.2.1
+    peerDependencies:
+      tslint: ^5.1.0
+      typescript: ^2.1.0 || ^3.0.0
+    resolution:
+      integrity: sha512-PDYjvpo0gN9IfMULwKk0KpVOPMhU6cNoT9VwCOLeDl/QS8v8W2yspRpFFuUS7/c5EIH/n8ApMi8TxJAz1tfFUA==
   /tslint-xo/0.9.0:
     dependencies:
       tslint-consistent-codestyle: 1.15.1
@@ -8415,6 +8464,20 @@ packages:
     dev: false
     engines:
       node: '>=6'
+    peerDependencies:
+      tslint: '>=5.11.0'
+    resolution:
+      integrity: sha512-Zk5jBdQVUaHEmR9TUoh1TJOjjCr7/nRplA+jDZBvucyBMx65pt0unTr6H/0HvrtSlucFvOMYsyBZE1W8b4AOig==
+  /tslint-xo/0.9.0/tslint@5.18.0+typescript@3.5.3:
+    dependencies:
+      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint-consistent-codestyle: /tslint-consistent-codestyle/1.15.1/tslint@5.18.0+typescript@3.5.3
+      tslint-eslint-rules: /tslint-eslint-rules/5.4.0/tslint@5.18.0+typescript@3.5.3
+      tslint-microsoft-contrib: /tslint-microsoft-contrib/5.2.1/tslint@5.18.0+typescript@3.5.3
+    dev: false
+    engines:
+      node: '>=6'
+    id: registry.npmjs.org/tslint-xo/0.9.0
     peerDependencies:
       tslint: '>=5.11.0'
     resolution:
@@ -8475,6 +8538,15 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+  /tsutils/2.28.0/typescript@3.5.3:
+    dependencies:
+      typescript: 3.5.3
+    dev: false
+    id: registry.npmjs.org/tsutils/2.28.0
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    resolution:
+      integrity: sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
   /tsutils/2.29.0:
     dependencies:
       tslib: 1.10.0
@@ -8499,6 +8571,17 @@ packages:
     dev: false
     engines:
       node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  /tsutils/3.17.1/typescript@3.5.3:
+    dependencies:
+      typescript: 3.5.3
+    dev: false
+    engines:
+      node: '>= 6'
+    id: registry.npmjs.org/tsutils/3.17.1
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     resolution:
@@ -9133,7 +9216,7 @@ packages:
       jju: 1.4.0
       lodash.once: 4.1.1
       npm-check-updates: 3.1.21
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
       yargs: 13.3.0
     dev: false
@@ -9152,7 +9235,7 @@ packages:
       '@oclif/parser': 3.8.4
       '@oclif/plugin-help': 2.2.1
       '@oclif/plugin-not-found': 1.2.2
-      '@oclif/tslint': 3.1.1
+      '@oclif/tslint': /@oclif/tslint/3.1.1/tslint@5.18.0+typescript@3.5.3
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.0
       '@types/js-yaml': 3.12.1
@@ -9162,6 +9245,7 @@ packages:
       '@types/node-fetch': 2.5.0
       '@types/tar': 4.0.3
       '@types/validator': 10.11.2
+      chalk: 2.4.2
       cli-ux: 5.3.1
       conf: 5.0.0
       dotenv: 8.0.0
@@ -9183,7 +9267,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-cli'
     resolution:
-      integrity: sha512-2VsCI4EBOKezLVNBlRQnQ36bYLXst4yLP287Td8L5D/yDzIk0MpQERf5GcgbIzP4WxqIMQE/mfKE724kvdAaVg==
+      integrity: sha512-uO/UZCrTTeLMl31qv8npQTDmiTzW+1WdnxpmH0PgzrWRWmQFnSzyZNYC0D/5ytdREIOH60XGyk2N0JVAoheGoA==
       tarball: 'file:projects/shift-cli.tgz'
     version: 0.0.0
   'file:projects/shift-code-transform.tgz':
@@ -9197,7 +9281,7 @@ packages:
       babel-plugin-tester: 6.4.0
       jest: 24.8.0
       jest-standard-reporter: 1.0.1
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/shift-code-transform'
@@ -9222,7 +9306,7 @@ packages:
       levelup: 4.1.0
       ramda: 0.26.1
       rmfr: 2.0.0
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/shift-db'
@@ -9233,7 +9317,7 @@ packages:
   'file:projects/shift-fetch-runtime.tgz':
     dependencies:
       '@types/node': 10.14.15
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/shift-fetch-runtime'
@@ -9278,7 +9362,7 @@ packages:
     dependencies:
       '@types/node': 10.14.15
       fast-json-patch: 2.2.1
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
       typescript-json-schema: 0.39.0
     dev: false
@@ -9289,9 +9373,9 @@ packages:
     version: 0.0.0
   'file:projects/shift-local-proxy.tgz':
     dependencies:
-      '@babel/cli': /@babel/cli/7.5.5/@babel!core@7.5.5
+      '@babel/cli': 7.5.5
       '@babel/core': 7.5.5
-      '@babel/plugin-transform-modules-commonjs': /@babel/plugin-transform-modules-commonjs/7.5.0/@babel!core@7.5.5
+      '@babel/plugin-transform-modules-commonjs': 7.5.0
       '@types/babel__core': 7.1.2
       '@types/bunyan': 1.8.6
       '@types/express': 4.17.0
@@ -9319,7 +9403,7 @@ packages:
       nanoid: 2.0.3
       nodemon: github.com/binaris/nodemon/4900b2d82bcc1b315b1df9bd80817bd86fbe37ed
       rimraf: 2.7.0
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
       walkdir: 0.4.1
     dev: false
@@ -9359,7 +9443,7 @@ packages:
       react: 16.9.0
       rxjs: 6.5.2
       sinon: 7.4.1
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/shift-subscriptions'
@@ -9375,7 +9459,7 @@ packages:
       fixture-stdout: 0.2.1
       jest: 24.8.0
       rmfr: 2.0.0
-      tslint: /tslint/5.18.0/typescript@3.5.3
+      tslint: 5.18.0
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/shiftjs-react-app'
@@ -9477,6 +9561,7 @@ specifiers:
   babel-plugin-tester: ^6.4.0
   bunyan: ^1.8.12
   bunyan-rotating-file-stream: ^1.6.3
+  chalk: ^2.4.2
   cli-ux: ^5.3.1
   conf: ^5.0.0
   deep-freeze: ^0.0.1


### PR DESCRIPTION
Otherwise unknown in this context but valid extra flags are not recognized

Also add chalk as dependency to help when running with rush