### PR TITLE
Tell Linguist (and GitHub) that shrinkwrap.json is generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,10 @@ shrinkwrap.yaml              merge=binary
 npm-shrinkwrap.json          merge=binary
 yarn.lock                    merge=binary
 
+# This is a generated file.  Tell Linguist at GitHub to prefer *not*
+# to show changes to it in PRs.
+common/config/rush/shrinkwrap.yaml    linguist-generated=true
+
 # Rush's JSON config files use JavaScript-style code comments.  The rule below prevents pedantic
 # syntax highlighters such as GitHub's from highlighting these comments as errors.  Your text editor
 # may also require a special configuration to allow comments in JSON.

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,5 +1,4 @@
 dependencies:
-  do_not_pull_with_this: 99
   '@babel/cli': 7.5.5
   '@babel/core': 7.5.5
   '@babel/parser': 7.5.5

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -1,4 +1,5 @@
 dependencies:
+  do_not_pull_with_this: 99
   '@babel/cli': 7.5.5
   '@babel/core': 7.5.5
   '@babel/parser': 7.5.5


### PR DESCRIPTION
This lets GitHub hide diffs in it by default.

Also my teleprinter is broken: get rid of CRs.

It looks like this (I pushed a bad change to shrinkwrap and now I'm resetting it, so you can see for yourself on this very PR):
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/7802932/63418027-0f300380-c40b-11e9-81dc-3738dadffe70.png">
