### PR TITLE
Upload less files

### DIFF
--- a/cli/src/commands/deploy.ts
+++ b/cli/src/commands/deploy.ts
@@ -47,7 +47,8 @@ export default class Deploy extends Command {
       const filesToExclude = new Set(['node_modules', 'backend', 'src'].map((f) => pathResolve(projectDir, f)));
       await copy(projectDir, stagingDir, {
         filter(src) {
-          return !filesToExclude.has(src) && !path.basename(src).startsWith('.');
+          return !filesToExclude.has(src) &&
+            !(path.dirname(src) === projectDir && path.basename(src).startsWith('.'));
         },
       });
 

--- a/common/changes/shift-cli/deploy-less_2019-08-23-18-18.json
+++ b/common/changes/shift-cli/deploy-less_2019-08-23-18-18.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "shift-cli",
+      "comment": "Deploy less files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "shift-cli",
+  "email": "vladimir@shiftjs.com"
+}


### PR DESCRIPTION
Avoid a flattened copy of build folder
Ignore all .dotfiles
Avoid adding bundle.tgz to bundle.tgz