### PR TITLE
Environment variables should start with SHIFT_ and match runtime

### DIFF
--- a/db-client/src/index.ts
+++ b/db-client/src/index.ts
@@ -42,14 +42,14 @@ export class DBHandler {
     auth: {
       v1: {
         // TODO(ariels): Update with prefixes from binaris/spice#616.
-        appId: process.env.APP_ID!,
-        apiKey: process.env.API_KEY!,
+        appId: process.env.SHIFT_APPLICATION_ID!,
+        apiKey: '<unused>',
       },
     },
   };
 
   constructor(options?: Options) {
-    this.client = new DBClient(`${process.env.DB_BASE_URL!}/v1`, merge(defaultOptions, options));
+    this.client = new DBClient(`${process.env.SHIFT_DB_BASE_URL!}/v1`, merge(defaultOptions, options));
   }
 
   public async get<T extends Serializable = any>(key: string): Promise<T | undefined> {

--- a/db-client/src/test/component/db.ts
+++ b/db-client/src/test/component/db.ts
@@ -27,8 +27,7 @@ async function listenOn(app: Koa): Promise<Server> {
   });
 }
 
-process.env.APP_ID = 'testing';
-process.env.API_KEY = '1234';
+process.env.SHIFT_APPLICATION_ID = 'testing';
 
 test.beforeEach(async (t) => {
   const dbDir = await promisify(mkdtemp)(path.join(tmpdir(), 'test-state-'), 'utf8');
@@ -43,7 +42,7 @@ test.beforeEach(async (t) => {
   const server = await listenOn(app);
   const port = (server.address() as unknown as AddressInfo).port;
   const url = `http://localhost:${port}`;
-  process.env.DB_BASE_URL = url;
+  process.env.SHIFT_DB_BASE_URL = url;
   // Instantiate DBHandler with proper URL set up.
   const client = new DBHandler({ timeoutMs: 1000 });
   t.context = {

--- a/local-proxy/src/server.ts
+++ b/local-proxy/src/server.ts
@@ -24,7 +24,7 @@ if (!localToken) {
 }
 
 function setupEnv({ port }: { port: number }) {
-  process.env.DB_BASE_URL = `http://localhost:${port}`;
+  process.env.SHIFT_DB_BASE_URL = `http://localhost:${port}`;
   // TODO(vogre): Used (at least) for DB, where it doesn't really
   //     matter locally.  Are better values available?
   process.env.APP_ID = 'local-app';
@@ -131,13 +131,13 @@ router.post('/invoke', async (ctx) => {
         };
         return;
       }
-      if (!process.env.DB_BASE_URL) {
+      if (!process.env.SHIFT_DB_BASE_URL) {
         // This can never happen, because POST can only occur after we
-        // start listening and set DB_BASE_URL.  Verify it just in
-        // case.
+        // start listening and set SHIFT_DB_BASE_URL.  Verify it just
+        // in case.
 
         // tslint:disable-next-line:no-console
-        console.error('[I] Invoked before local DB_BASE_URL was set; local DB might break');
+        console.error('[I] Invoked before local SHIFT_DB_BASE_URL was set; local DB might break');
       }
       const mod = require(joinedDir);
       fn = mod[handler];


### PR DESCRIPTION
Use `SHIFT_*` environment variables.  These are passed on the actual
runtime.