### PR TITLE
Enable host and origin checks in local and remote serving

### DIFF
--- a/common/changes/@binaris/shift-local-proxy/local-proxy-host-check_2019-09-01-14-13.json
+++ b/common/changes/@binaris/shift-local-proxy/local-proxy-host-check_2019-09-01-14-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-local-proxy",
+      "comment": "Verify Host and Origin headers on local requests",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-local-proxy",
+  "email": "vladimir@shiftjs.com"
+}

--- a/common/changes/@binaris/shift-server-function/local-proxy-host-check_2019-09-01-14-13.json
+++ b/common/changes/@binaris/shift-server-function/local-proxy-host-check_2019-09-01-14-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-server-function",
+      "comment": "Add support for Host and Origin verification",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-server-function",
+  "email": "vladimir@shiftjs.com"
+}

--- a/common/config/rush/shrinkwrap.yaml
+++ b/common/config/rush/shrinkwrap.yaml
@@ -4,8 +4,7 @@ dependencies:
   '@babel/parser': 7.5.5
   '@babel/plugin-transform-modules-commonjs': 7.5.0
   '@babel/types': 7.5.5
-  '@binaris/shift-interfaces-koa-server': 0.4.0
-  '@binaris/shift-server-function': 0.0.1
+  '@binaris/shift-interfaces-node-client': 0.3.0
   '@binaris/spice-node-client': 0.0.2-rc.17
   '@oclif/command': 1.5.18
   '@oclif/config': 1.13.3
@@ -60,6 +59,7 @@ dependencies:
   '@types/validator': 10.11.3
   '@types/yargs': 13.0.2
   abort-controller: 2.0.3
+  address: 1.1.2
   ajv: 6.10.2
   async-mutex: 0.1.3
   babel-plugin-macros: 2.6.1
@@ -470,21 +470,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
-  /@binaris/shift-interfaces-koa-server/0.4.0:
-    dependencies:
-      '@types/koa': 2.0.49
-      '@types/koa-bodyparser': 5.0.2
-      '@types/koa-router': 7.0.35
-      ajv: 6.10.2
-      koa: 2.8.1
-      koa-bodyparser: 4.2.1
-      koa-router: 7.4.0
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      '@types/node': '>=8.0.0'
-    resolution:
-      integrity: sha512-RJCwZVcHabvM5zGflwFJ5TmjZPdUOsV+npgfJ798VupCHBa2aKqU6qZvQx7OFyPtv7jFFLmCmynXKcULZS9+dw==
   /@binaris/shift-interfaces-koa-server/0.4.0/@types!node@10.14.16:
     dependencies:
       '@types/koa': 2.0.49
@@ -1432,6 +1417,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+  /address/1.1.2:
+    dev: false
+    engines:
+      node: '>= 0.12.0'
+    resolution:
+      integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
   /agent-base/4.2.1:
     dependencies:
       es6-promisify: 5.0.0
@@ -9392,7 +9383,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-db-testsuite'
     resolution:
-      integrity: sha512-XrO64K0/sWu1oT3+tBzx3bhV7voTCyIX4c8e0kFQ+uD26Zg0UruQHSKIYhPNsxNMlF6C2Dk/MSo8zuG6ORJKUA==
+      integrity: sha512-2F8LtEa3p3RWIIz0AtUgyBaiIHghXWpgrlR91rT7UuqFzG4yptXZqHPHT8UwS35hcLYjvtupQAvfBLfw8pZkvg==
       tarball: 'file:projects/shift-db-testsuite.tgz'
     version: 0.0.0
   'file:projects/shift-db.tgz':
@@ -9407,7 +9398,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-db'
     resolution:
-      integrity: sha512-SzxxEsYJiIdBhZfclANbOBh43F1M41djTHCxSVnBZzLsxjgelG0K8LA8atXeMtMb5M6QZEuQfJU49Qts/83gLQ==
+      integrity: sha512-WrzmkWBTxdUBRqXrXYxdMdQIPxKY2+IBZoeFP4jFj7B94/Qv2TAcYroipQ8mIJejqCYM8D7kTYlXWW0bLfXr1w==
       tarball: 'file:projects/shift-db.tgz'
     version: 0.0.0
   'file:projects/shift-fetch-runtime.tgz':
@@ -9494,7 +9485,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-leveldb-server'
     resolution:
-      integrity: sha512-juRvZ0IehJoc7CSY2G5lurx01Fyx5co6MRy/M6kH7Xk13+aKE0PXK/oCGldcwBRkJkb++L4HtKjUJrTqPGNtyA==
+      integrity: sha512-LzPHucPENSCjuK03o+7b3ubIodymCmdzkuA6nKWUkEokppzKdDDh4H2IOdNEFYH/1A9WzaRfHTAvMgr+h+FFOw==
       tarball: 'file:projects/shift-leveldb-server.tgz'
     version: 0.0.0
   'file:projects/shift-local-proxy.tgz':
@@ -9517,6 +9508,7 @@ packages:
       '@types/nanoid': 2.0.0
       '@types/node': 10.14.16
       '@types/rimraf': 2.0.2
+      address: 1.1.2
       ava: 2.3.0
       bunyan: 1.8.12
       bunyan-rotating-file-stream: 1.6.3
@@ -9537,7 +9529,7 @@ packages:
     dev: false
     name: '@rush-temp/shift-local-proxy'
     resolution:
-      integrity: sha512-ERo+1qPZCIoE3NJRH/0o5/mr2JJK+zOZSyuBdimQxFKf1/g11YB1zZmKzxKQgt4qB+G9B8oY94AUnCI+9JaC3A==
+      integrity: sha512-8x8B3xZuFc9ZRg30O9VDb12WaMws0WDe7GmXgoByyj6UI+sd0GAIT+jQaQ/u56YxdMMgOyLUjp9EPBIqIjeGVg==
       tarball: 'file:projects/shift-local-proxy.tgz'
     version: 0.0.0
   'file:projects/shift-server-function.tgz':
@@ -9604,8 +9596,7 @@ specifiers:
   '@babel/parser': ^7.5.5
   '@babel/plugin-transform-modules-commonjs': ^7.5.0
   '@babel/types': ^7.5.5
-  '@binaris/shift-interfaces-koa-server': 0.4.0
-  '@binaris/shift-server-function': 0.0.1
+  '@binaris/shift-interfaces-node-client': 0.3.0
   '@binaris/spice-node-client': 0.0.2-rc.17
   '@oclif/command': ^1.5.18
   '@oclif/config': ^1.13.2
@@ -9660,6 +9651,7 @@ specifiers:
   '@types/validator': ^10.11.2
   '@types/yargs': ^13.0.2
   abort-controller: ^2.0.2
+  address: ^1.1.2
   ajv: ^6.5.5
   async-mutex: ^0.1.3
   babel-plugin-macros: ^2.6.1

--- a/local-proxy/package.json
+++ b/local-proxy/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rm -rf dist/ && tsc",
     "lint": "tslint -c ../common/tslint.yml -p .",
-    "test": "ava -v dist/test/*.js"
+    "test": "ava -v dist/test/*.test.js"
   },
   "author": "",
   "license": "MIT",

--- a/local-proxy/package.json
+++ b/local-proxy/package.json
@@ -17,10 +17,11 @@
     "@babel/cli": "^7.5.5",
     "@babel/core": "^7.5.5",
     "@babel/plugin-transform-modules-commonjs": "^7.5.0",
-    "@binaris/shift-server-function": "0.0.1",
     "@binaris/shift-interfaces-koa-server": "0.4.0",
     "@binaris/shift-leveldb-server": "0.0.3",
+    "@binaris/shift-server-function": "0.0.2",
     "@types/express": "^4.17.0",
+    "address": "^1.1.2",
     "bunyan": "^1.8.12",
     "bunyan-rotating-file-stream": "^1.6.3",
     "express": "^4.17.1",
@@ -33,6 +34,9 @@
     "nodemon": "^1.19.1",
     "rimraf": "^2.6.3",
     "walkdir": "^0.4.1"
+  },
+  "peerDependencies": {
+    "@binaris/shift-db": "0.5.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.2",
@@ -52,8 +56,5 @@
     "lodash": "^4.17.15",
     "tslint": "^5.18.0",
     "typescript": "^3.5.3"
-  },
-  "peerDependencies": {
-    "@binaris/shift-db": "0.5.0"
   }
 }

--- a/local-proxy/src/index.ts
+++ b/local-proxy/src/index.ts
@@ -76,14 +76,11 @@ export function startProxy(
 
 export function setupProxy(sourceDir: string) {
   const rootDir = path.resolve(sourceDir, '..');
-  const shiftServer = new Server(
-    path.join(rootDir, 'public'),
-    undefined,
-    undefined,
-    undefined,
-    address.ip(),
-    process.env.HOST || '0.0.0.0'
-  );
+  const shiftServer = new Server({
+    directory: path.join(rootDir, 'public'),
+    publicHost: address.ip(),
+    listenHost: process.env.HOST || '0.0.0.0',
+  });
   const localToken = nanoid();
   const httpProxy = new proxy();
   httpProxy.on('error', (err: any) => console.error(err.stack));

--- a/local-proxy/src/index.ts
+++ b/local-proxy/src/index.ts
@@ -97,9 +97,6 @@ export function setupProxy(sourceDir: string) {
       }
       switch (decision.action) {
         case 'handleInvoke': {
-          if (!shiftServer.checkHeadersLocalHost(req.headers, 'origin')) {
-            return res.sendStatus(403);
-          }
           const port = await promiseHolder.portPromise;
           return httpProxy.web(req, res, {
             target: `http://localhost:${port}/`,

--- a/local-proxy/src/test/corsNotAllowed.test.ts
+++ b/local-proxy/src/test/corsNotAllowed.test.ts
@@ -1,32 +1,9 @@
-import * as http from 'http';
-import { AddressInfo } from 'net';
-import express from 'express';
-import { setupProxy } from '../index';
 import anyTest, { TestInterface } from 'ava';
-import path from 'path';
+import { setupTestHooks, LocalProxyTestInterface } from './setupHooks';
 import got from 'got';
 
-const test = anyTest as TestInterface<{
-  port: number,
-  server: http.Server,
-}>;
-
-// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
-test.beforeEach(async (t) => {
-  const app = express();
-  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
-  const server = t.context.server = http.createServer(app);
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const { port } = server.address() as AddressInfo;
-  t.context.port = port;
-});
-
-test.afterEach.always((t) => {
-  t.context.server.close();
-});
+const test = anyTest as TestInterface<LocalProxyTestInterface>;
+setupTestHooks(test);
 
 test('CORS not allowed', async (t) => {
   const response = await got(`http://127.0.0.1:${t.context.port}/invoke`, {

--- a/local-proxy/src/test/corsNotAllowed.test.ts
+++ b/local-proxy/src/test/corsNotAllowed.test.ts
@@ -1,0 +1,38 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import { setupProxy } from '../index';
+import anyTest, { TestInterface } from 'ava';
+import path from 'path';
+import got from 'got';
+
+const test = anyTest as TestInterface<{
+  port: number,
+  server: http.Server,
+}>;
+
+// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
+test.beforeEach(async (t) => {
+  const app = express();
+  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
+  const server = t.context.server = http.createServer(app);
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  t.context.port = port;
+});
+
+test.afterEach.always((t) => {
+  t.context.server.close();
+});
+
+test('CORS not allowed', async (t) => {
+  const response = await got(`http://127.0.0.1:${t.context.port}/invoke`, {
+    method: 'OPTIONS',
+    headers: { 'Access-Control-Allow-Method': 'POST', Origin: 'evil.com' },
+  });
+  t.is(response.statusCode, 200);
+  t.is(response.headers['access-control-allow-origin'], undefined);
+});

--- a/local-proxy/src/test/flakyInvoke.test.ts
+++ b/local-proxy/src/test/flakyInvoke.test.ts
@@ -11,6 +11,7 @@ import { range } from 'lodash';
 // This means that if a test run fails there is most likely a bug in the code
 test('Regression #36', async (t) => {
   t.timeout(10000);
+  // TODO: duplicate between files due to nodemon requiring to be used in exactly one process
   const app = express();
   setupProxy(path.join(__dirname, 'fixture/backend'))(app);
   const server = http.createServer(app);
@@ -21,9 +22,7 @@ test('Regression #36', async (t) => {
   const { port } = server.address() as AddressInfo;
   const responses = await Promise.all(
     range(100).map(() => got.post(`http://127.0.0.1:${port}/invoke`, {
-      headers: {
-        origin: 'localhost',
-      },
+      headers: {},
       body: { path: 'dummyBackend.js', args: [], handler: 'hello', },
       json: true,
     }))

--- a/local-proxy/src/test/flakyInvoke.test.ts
+++ b/local-proxy/src/test/flakyInvoke.test.ts
@@ -21,6 +21,9 @@ test('Regression #36', async (t) => {
   const { port } = server.address() as AddressInfo;
   const responses = await Promise.all(
     range(100).map(() => got.post(`http://127.0.0.1:${port}/invoke`, {
+      headers: {
+        origin: 'localhost',
+      },
       body: { path: 'dummyBackend.js', args: [], handler: 'hello', },
       json: true,
     }))

--- a/local-proxy/src/test/flakyInvoke.test.ts
+++ b/local-proxy/src/test/flakyInvoke.test.ts
@@ -1,27 +1,17 @@
-import * as http from 'http';
-import { AddressInfo } from 'net';
-import express from 'express';
-import { setupProxy } from '../index';
-import test from 'ava';
-import path from 'path';
+import anyTest, { TestInterface } from 'ava';
+import { setupTestHooks, LocalProxyTestInterface } from './setupHooks';
 import got from 'got';
 import { range } from 'lodash';
+
+const test = anyTest as TestInterface<LocalProxyTestInterface>;
+setupTestHooks(test);
 
 // This test should be considered NOT flaky
 // This means that if a test run fails there is most likely a bug in the code
 test('Regression #36', async (t) => {
   t.timeout(10000);
-  // TODO: duplicate between files due to nodemon requiring to be used in exactly one process
-  const app = express();
-  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
-  const server = http.createServer(app);
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const { port } = server.address() as AddressInfo;
   const responses = await Promise.all(
-    range(100).map(() => got.post(`http://127.0.0.1:${port}/invoke`, {
+    range(100).map(() => got.post(`http://127.0.0.1:${t.context.port}/invoke`, {
       headers: {},
       body: { path: 'dummyBackend.js', args: [], handler: 'hello', },
       json: true,

--- a/local-proxy/src/test/invalidHost.test.ts
+++ b/local-proxy/src/test/invalidHost.test.ts
@@ -1,32 +1,9 @@
-import * as http from 'http';
-import { AddressInfo } from 'net';
-import express from 'express';
-import { setupProxy } from '../index';
 import anyTest, { TestInterface } from 'ava';
-import path from 'path';
+import { setupTestHooks, LocalProxyTestInterface } from './setupHooks';
 import got from 'got';
 
-const test = anyTest as TestInterface<{
-  port: number,
-  server: http.Server,
-}>;
-
-// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
-test.beforeEach(async (t) => {
-  const app = express();
-  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
-  const server = t.context.server = http.createServer(app);
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const { port } = server.address() as AddressInfo;
-  t.context.port = port;
-});
-
-test.afterEach.always((t) => {
-  t.context.server.close();
-});
+const test = anyTest as TestInterface<LocalProxyTestInterface>;
+setupTestHooks(test);
 
 test('Invalid Host', async (t) => {
   const reqPromise = got.post(`http://127.0.0.1:${t.context.port}/invoke`, {

--- a/local-proxy/src/test/invalidHost.test.ts
+++ b/local-proxy/src/test/invalidHost.test.ts
@@ -1,0 +1,40 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import { setupProxy } from '../index';
+import anyTest, { TestInterface } from 'ava';
+import path from 'path';
+import got from 'got';
+
+const test = anyTest as TestInterface<{
+  port: number,
+  server: http.Server,
+}>;
+
+// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
+test.beforeEach(async (t) => {
+  const app = express();
+  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
+  const server = t.context.server = http.createServer(app);
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  t.context.port = port;
+});
+
+test.afterEach.always((t) => {
+  t.context.server.close();
+});
+
+test('Invalid Host', async (t) => {
+  const reqPromise = got.post(`http://127.0.0.1:${t.context.port}/invoke`, {
+    headers: {
+      host: 'evil.com',
+    },
+    body: { path: 'dummyBackend.js', args: [], handler: 'hello', },
+    json: true,
+  });
+  await t.throwsAsync(reqPromise, 'Response code 403 (Forbidden)');
+});

--- a/local-proxy/src/test/nonWhitelistedNotAllowed.test.ts
+++ b/local-proxy/src/test/nonWhitelistedNotAllowed.test.ts
@@ -1,0 +1,38 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import express from 'express';
+import { setupProxy } from '../index';
+import anyTest, { TestInterface } from 'ava';
+import path from 'path';
+import got from 'got';
+
+const test = anyTest as TestInterface<{
+  port: number,
+  server: http.Server,
+}>;
+
+// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
+test.beforeEach(async (t) => {
+  const app = express();
+  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
+  const server = t.context.server = http.createServer(app);
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  t.context.port = port;
+});
+
+test.afterEach.always((t) => {
+  t.context.server.close();
+});
+
+test('Non-whitelisted modules not allowed by default', async (t) => {
+  const reqPromise = got.post(`http://127.0.0.1:${t.context.port}/invoke`, {
+    headers: {},
+    body: { path: '/', args: [], handler: 'hello', },
+    json: true,
+  });
+  await t.throwsAsync(reqPromise, 'Response code 403 (Forbidden)');
+});

--- a/local-proxy/src/test/nonWhitelistedNotAllowed.test.ts
+++ b/local-proxy/src/test/nonWhitelistedNotAllowed.test.ts
@@ -1,32 +1,9 @@
-import * as http from 'http';
-import { AddressInfo } from 'net';
-import express from 'express';
-import { setupProxy } from '../index';
 import anyTest, { TestInterface } from 'ava';
-import path from 'path';
+import { setupTestHooks, LocalProxyTestInterface } from './setupHooks';
 import got from 'got';
 
-const test = anyTest as TestInterface<{
-  port: number,
-  server: http.Server,
-}>;
-
-// TODO: duplicate between files due to nodemon requiring to be used in exactly one process
-test.beforeEach(async (t) => {
-  const app = express();
-  setupProxy(path.join(__dirname, 'fixture/backend'))(app);
-  const server = t.context.server = http.createServer(app);
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '127.0.0.1', resolve);
-  });
-  const { port } = server.address() as AddressInfo;
-  t.context.port = port;
-});
-
-test.afterEach.always((t) => {
-  t.context.server.close();
-});
+const test = anyTest as TestInterface<LocalProxyTestInterface>;
+setupTestHooks(test);
 
 test('Non-whitelisted modules not allowed by default', async (t) => {
   const reqPromise = got.post(`http://127.0.0.1:${t.context.port}/invoke`, {

--- a/local-proxy/src/test/setupHooks.ts
+++ b/local-proxy/src/test/setupHooks.ts
@@ -1,0 +1,29 @@
+import { TestInterface } from 'ava';
+import express from 'express';
+import path from 'path';
+import http from 'http';
+import { AddressInfo } from 'net';
+import { setupProxy } from '../index';
+
+export interface LocalProxyTestInterface {
+  port: number;
+  server: http.Server;
+}
+
+// TODO: each file setups a single test since nodemon must be used in exactly one proces
+export function setupTestHooks(test: TestInterface<LocalProxyTestInterface>) {
+  test.beforeEach(async (t) => {
+    const app = express();
+    setupProxy(path.join(__dirname, 'fixture/backend'))(app);
+    const server = t.context.server = http.createServer(app);
+    await new Promise((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    t.context.port = port;
+  });
+  test.afterEach.always((t) => {
+    t.context.server.close();
+  });
+}

--- a/server-function/src/index.ts
+++ b/server-function/src/index.ts
@@ -3,6 +3,8 @@ import fs from 'mz/fs';
 import mimeTypes from 'mime-types';
 import ms from 'milliseconds';
 import fresh from 'fresh';
+import url from 'url';
+import net from 'net';
 
 // create-react-app uses only 32 bits for hashes, allow caching for a limited
 // time for lower chance of collision
@@ -44,16 +46,20 @@ export class Server {
     private directory: string,
     private extensions: string[] = ['.html'],
     private cachedPath = '/static',
+    private allowedHosts: string[] = [],
+    private publicHost?: string,
+    private listenHost?: string,
   ) {
   }
-  public async handle(url: string, headers: { [k: string]: string | string[] | undefined }): Promise<Decision> {
-    if (url === '/invoke') {
+
+  public async handle(reqUrl: string, headers: { [k: string]: string | string[] | undefined }): Promise<Decision> {
+    if (reqUrl === '/invoke') {
       return { action: 'handleInvoke' };
     }
-    if (url === '/') {
+    if (reqUrl === '/') {
       return this.handle('/index.html', headers);
     }
-    const urlWithRemovedSegements = path.join('/', url);
+    const urlWithRemovedSegements = path.join('/', reqUrl);
     const fullPath = path.join(this.directory, urlWithRemovedSegements);
     let foundPath: string | undefined;
     let foundStat: fs.Stats | undefined;
@@ -98,9 +104,116 @@ export class Server {
         status: 404,
       };
     }
-    if (url === '/index.html') {
+    if (reqUrl === '/index.html') {
       return { action: 'sendStatus', status: 404 };
     }
     return this.handle('/index.html', headers);
+  }
+
+  private getHostnameFromHeaders(
+    headers: { [k: string]: string | string[] | undefined },
+    headerToCheck: string = 'host'
+  ): string | false {
+    // get the Host header and extract hostname
+    // we don't care about port not matching
+
+    const hostHeader: string = headers[headerToCheck] as string;
+
+    if (!hostHeader) {
+      return false;
+    }
+
+    // use the node url-parser to retrieve the hostname from the host-header.
+    const hostname = url.parse(
+      // if hostHeader doesn't have scheme, add // for parsing.
+      /^(.+:)?\/\//.test(hostHeader) ? hostHeader : `//${hostHeader}`,
+      false,
+      true
+    ).hostname;
+
+    if (!hostname) {
+      return false;
+    }
+
+    return hostname;
+  }
+
+  // adapted from webpack-dev-server lib/Server.js:checkHeaders
+  // https://github.com/webpack/webpack-dev-server/blob/ea61454e87ffa113c485b9ca4b53e586be3b0917/lib/Server.js#L821
+  // and split into two methods:
+  // checkHeadersAllowedHost - which only verifies a finite list of hosts
+  // checkHeadersLocalHost - which allows special cases like 'localhost', and the listening host
+  public checkHeadersAllowedHost(
+    headers: { [k: string]: string | string[] | undefined },
+    headerToCheck: string = 'host'
+  ) {
+
+    const hostname = this.getHostnameFromHeaders(headers, headerToCheck);
+    if (!hostname) {
+      return false;
+    }
+    // allow if hostname is in allowedHosts
+    if (this.allowedHosts.length) {
+      for (const allowedHost of this.allowedHosts) {
+
+        if (allowedHost === hostname) {
+          return true;
+        }
+
+        // support "." as a subdomain wildcard
+        // e.g. ".example.com" will allow "example.com", "www.example.com", "subdomain.example.com", etc
+        if (allowedHost[0] === '.') {
+          // "example.com"
+          if (hostname === allowedHost.substring(1)) {
+            return true;
+          }
+          // "*.example.com"
+          if (hostname.endsWith(allowedHost)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    // disallow
+    return false;
+  }
+
+  public checkHeadersLocalHost(
+    headers: { [k: string]: string | string[] | undefined },
+    headerToCheck: string = 'host'
+  ) {
+    const hostname = this.getHostnameFromHeaders(headers, headerToCheck);
+    if (!hostname) {
+      return false;
+    }
+    // always allow requests with explicit IPv4 or IPv6-address.
+    // A note on IPv6 addresses:
+    // hostHeader will always contain the brackets denoting
+    // an IPv6-address in URLs,
+    // these are removed from the hostname in url.parse(),
+    // so we have the pure IPv6-address in hostname.
+    if (net.isIPv4(hostname) || net.isIPv6(hostname)) {
+      return true;
+    }
+    // always allow localhost host, for convience
+    if (hostname === 'localhost') {
+      return true;
+    }
+    // allow hostname of listening adress
+    if (hostname === this.listenHost) {
+      return true;
+    }
+    // also allow public hostname if provided
+    if (typeof this.publicHost === 'string') {
+      const idxPublic = this.publicHost.indexOf(':');
+
+      const publicHostname =
+        idxPublic >= 0 ? this.publicHost.substr(0, idxPublic) : this.publicHost;
+
+      if (hostname === publicHostname) {
+        return true;
+      }
+    }
   }
 }

--- a/server-function/src/index.ts
+++ b/server-function/src/index.ts
@@ -41,15 +41,30 @@ interface Invoke {
 
 type Decision = ServeFile | Invoke | SendStatus;
 
+interface ServerOptions {
+  directory: string;
+  extensions?: string[];
+  cachedPath?: string;
+  allowedHosts?: string[];
+  publicHost?: string;
+  listenHost?: string;
+}
+
 export class Server {
-  constructor(
-    private directory: string,
-    private extensions: string[] = ['.html'],
-    private cachedPath = '/static',
-    private allowedHosts: string[] = [],
-    private publicHost?: string,
-    private listenHost?: string,
-  ) {
+  private directory: string;
+  private extensions: string[];
+  private cachedPath: string;
+  private allowedHosts: string[];
+  private publicHost?: string;
+  private listenHost?: string;
+
+  constructor(options: ServerOptions) {
+    this.directory = options.directory;
+    this.extensions = options.extensions || ['.html'];
+    this.cachedPath = options.cachedPath || '/static';
+    this.allowedHosts = options.allowedHosts || [];
+    this.publicHost = options.publicHost;
+    this.listenHost = options.listenHost;
   }
 
   public async handle(reqUrl: string, headers: { [k: string]: string | string[] | undefined }): Promise<Decision> {

--- a/server-function/src/serveBinaris.ts
+++ b/server-function/src/serveBinaris.ts
@@ -4,7 +4,7 @@ import { resolve as pathResolve } from 'path';
 import { BinarisFunction, FunctionContext } from './binaris';
 
 const allowedHosts = (process.env.SHIFT_APPLICATION_DOMAINS || '').split(',');
-const shiftServer = new Server('./build', undefined, undefined, allowedHosts);
+const shiftServer = new Server({ directory: './build', allowedHosts });
 
 interface InvokeRequest {
   path: string;

--- a/server-function/src/test/serve.test.ts
+++ b/server-function/src/test/serve.test.ts
@@ -8,13 +8,13 @@ const examplePath = path.join(__dirname, 'examples/index_with_static/');
 const examplePathWith404 = path.join(__dirname, 'examples/index_with_404/');
 
 async function testServer(t: ExecutionContext, url: string, expected: any) {
-  const server = new Server(examplePath);
+  const server = new Server({ directory: examplePath });
   const value = await server.handle(url, {});
   t.deepEqual(expected, value);
 }
 
 async function testServerWith404(t: ExecutionContext, url: string, expected: any) {
-  const server = new Server(examplePathWith404);
+  const server = new Server({ directory: examplePathWith404 });
   const value = await server.handle(url, {});
   t.deepEqual(expected, value);
 }


### PR DESCRIPTION
This is re-implementing the webpack-dev-server checks so that they are
available both locally and remotely

Fixes #98.