### PR TITLE
Don't use unexported type BabelTypes.BaseNode

### DIFF
--- a/code-transform/src/common.ts
+++ b/code-transform/src/common.ts
@@ -4,11 +4,15 @@ export function getFunctionName(e: BabelTypes.FunctionDeclaration, t: typeof Bab
   return t.isIdentifier(e.id) ? e.id.name : undefined;
 }
 
-export function isExposedStatement(node: BabelTypes.BaseNode) {
+interface WithBabelLeadingComments {
+  leadingComments: ReadonlyArray<BabelTypes.Comment> | null;
+}
+
+export function isExposedStatement(node: WithBabelLeadingComments) {
   return node.leadingComments && node.leadingComments.some((comment) => /@expose/.test(comment.value));
 }
 
-export function isTypeScriptGeneratedExport(e: BabelTypes.BaseNode, t: typeof BabelTypes, funcName: string) {
+export function isTypeScriptGeneratedExport(e: object, t: typeof BabelTypes, funcName: string) {
   return t.isExpressionStatement(e) &&
     t.isAssignmentExpression(e.expression) &&
     e.expression.operator === '=' &&

--- a/common/changes/@binaris/shift-code-transform/nocompile_2019-09-08-12-36.json
+++ b/common/changes/@binaris/shift-code-transform/nocompile_2019-09-08-12-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@binaris/shift-code-transform",
+      "type": "none"
+    }
+  ],
+  "packageName": "@binaris/shift-code-transform",
+  "email": "ariels@shiftjs.com"
+}


### PR DESCRIPTION
Instead:

1. In one instance _explicitly_ type out the desired `leadingComments`
   field (to identify comments with `@expose`),
2. In the other instance use `object`: `isExpressionStatement` anyway
   expects that type and will cast to an `ExpressionStatement`.