### PR TITLE
Dummy change

### DIFF
--- a/common/changes/@binaris/shift-server-function/republish-server-function_2019-09-09-09-03.json
+++ b/common/changes/@binaris/shift-server-function/republish-server-function_2019-09-09-09-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shift-server-function",
+      "comment": "Republish (previous version incorrectly tagged)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shift-server-function",
+  "email": "vladimir@shiftjs.com"
+}


### PR DESCRIPTION
Force republish of `@binaris/shift-server-function` (was published as 0.0.3 on septemeber 4 but can't republish immutable version)