### PR TITLE
Remove @binaris/shift-leveldb-server

### DIFF
--- a/common/changes/@binaris/shiftjs-react-app/rm-leveldb-direct-dep_2019-09-09-16-35.json
+++ b/common/changes/@binaris/shiftjs-react-app/rm-leveldb-direct-dep_2019-09-09-16-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@binaris/shiftjs-react-app",
+      "comment": "Remove @binaris/shift-leveldb-server as direct dependency",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@binaris/shiftjs-react-app",
+  "email": "vladimir@shiftjs.com"
+}

--- a/shiftjs-react-app/src/steps.ts
+++ b/shiftjs-react-app/src/steps.ts
@@ -51,7 +51,6 @@ export function installPackages(): Promise<string> {
       '@binaris/shift-code-transform',
       '@binaris/shift-fetch-runtime',
       '@binaris/shift-db',
-      '@binaris/shift-leveldb-server',
       '@binaris/shift-server-function',
     ];
     const args = [


### PR DESCRIPTION
The package is installed as a dependency of local-proxy, it shouldn't
be required as a direct dependency

This essentially reverts #179 